### PR TITLE
Ensure admin schema upgrades run during startup

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,3 @@
+"""SimuNet backend package."""
+
+__all__ = ["app", "db"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,123 +1,1380 @@
-import os, json, uuid
-from datetime import datetime
-from typing import Optional
+"""FastAPI application exposing health and static file endpoints for SimuNet."""
 
-from fastapi import FastAPI, HTTPException, Query, Depends, status
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import OAuth2PasswordBearer  # if you’re using auth
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+import hashlib
+import secrets
+import types
+import importlib
+import importlib.util
+import random
+from contextlib import contextmanager
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Annotated
+
+from fastapi import FastAPI, HTTPException, Query, status
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
+try:  # pragma: no cover - optional when running without SQLAlchemy
+    from sqlalchemy.orm import joinedload
+except Exception:  # pragma: no cover - keep optional dependency soft
+    joinedload = None  # type: ignore[assignment]
 
-app=FastAPI()
-@app.get('/status')
-def s(): return {'ok':True,'db':False}
+app = FastAPI()
 
-# DB (Neon) if DATABASE_URL set; else JSON store
 DB_AVAILABLE = False
 DB_ERROR = None
+
+BACKEND_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = BACKEND_DIR.parent
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _load_db_module():
+    """Import the database module regardless of deployment layout."""
+
+    module_name = "backend.db"
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        pass
+
+    spec = importlib.util.spec_from_file_location(module_name, BACKEND_DIR / "db.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise ImportError("Unable to load backend.db module")
+
+    module = importlib.util.module_from_spec(spec)
+    # Ensure both the package and module entries exist for downstream imports.
+    package = sys.modules.get("backend")
+    if package is None:
+        package = types.ModuleType("backend")
+        sys.modules["backend"] = package
+    if not getattr(package, "__path__", None):
+        package.__path__ = [str(BACKEND_DIR)]
+
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+db_module = _load_db_module()
+
 try:
-    import db
-    DB_AVAILABLE, DB_ERROR = db.ensure_db()
-except Exception as _e:
-    DB_AVAILABLE, DB_ERROR = False, str(_e)
+    DB_AVAILABLE, DB_ERROR = db_module.ensure_db()
+except Exception as exc:  # pragma: no cover - keep API responsive on DB failure
+    DB_AVAILABLE, DB_ERROR = False, str(exc)
+
+USE_DB = bool(DB_AVAILABLE and getattr(db_module, "SessionLocal", None))
 
 
-# Serve the frontend from the same container
+STATE_PATH = Path(os.path.join(os.path.dirname(__file__), "data", "state.json"))
+
+SIMUNET_CREATOR_EMAIL = "ops@simunet.local"
+
+MSFS_MISSIONS = [
+    {
+        "title": "Cascade Relief Hop",
+        "payload": "Medical relief packages",
+        "weight_lbs": (5200, 6800),
+        "deadline_hours": (4, 9),
+        "departure": "KSEA",
+        "arrival": "KPDX",
+        "notes": "Coordinate with Portland ground crew for hand-off on arrival.",
+    },
+    {
+        "title": "Northern Lights Cargo",
+        "payload": "Navigation beacons",
+        "weight_lbs": (3800, 5400),
+        "deadline_hours": (6, 12),
+        "departure": "PAFA",
+        "arrival": "PANC",
+        "notes": "Watch for icing along the Alaska Range and maintain radio contact with Anchorage Center.",
+    },
+    {
+        "title": "Island Supply Shuttle",
+        "payload": "Island hospital supplies",
+        "weight_lbs": (2600, 4200),
+        "deadline_hours": (5, 10),
+        "departure": "PHNL",
+        "arrival": "PHOG",
+        "notes": "Plan for strong trade winds on approach into Maui; deliver by dusk for coastal clinics.",
+    },
+    {
+        "title": "Rocky Mountain Survey",
+        "payload": "Aerial mapping equipment",
+        "weight_lbs": (3100, 4700),
+        "deadline_hours": (8, 14),
+        "departure": "KDEN",
+        "arrival": "KSLC",
+        "notes": "Collect terrain imagery en route over the Uintas before descending into Salt Lake City.",
+    },
+    {
+        "title": "Arctic Research Drop",
+        "payload": "Scientific instruments",
+        "weight_lbs": (4500, 6200),
+        "deadline_hours": (7, 16),
+        "departure": "BGTL",
+        "arrival": "BGSF",
+        "notes": "Limited daylight window — prioritize timely departure and monitor runway conditions in Greenland.",
+    },
+    {
+        "title": "Coastal Weather Run",
+        "payload": "Automated weather stations",
+        "weight_lbs": (3300, 5100),
+        "deadline_hours": (3, 7),
+        "departure": "CYVR",
+        "arrival": "CYYJ",
+        "notes": "Distribute payload to Victoria field team; low ceilings expected over Strait of Georgia.",
+    },
+    {
+        "title": "High Desert Calibration",
+        "payload": "Survey calibration sensors",
+        "weight_lbs": (3400, 5200),
+        "deadline_hours": (5, 11),
+        "departure": "KABQ",
+        "arrival": "KPHX",
+        "notes": "Calibrate the new desert survey array before the afternoon thermal activity picks up.",
+    },
+    {
+        "title": "Great Lakes Ferry",
+        "payload": "Freshwater research buoys",
+        "weight_lbs": (2900, 4500),
+        "deadline_hours": (4, 8),
+        "departure": "KDTW",
+        "arrival": "CYYZ",
+        "notes": "Toronto team will meet you at the Cargo 6 stand — keep customs documents ready for quick transfer.",
+    },
+]
+
+MSFS_DEFAULT_LEGS = [
+    {"seq": 1, "mode": "flight"},
+]
+
+
+def _isoformat(ts: datetime | str | None) -> str | None:
+    if ts is None:
+        return None
+    if isinstance(ts, str):
+        return ts
+    value = ts
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _now_iso(ts: datetime | None = None) -> str:
+    return _isoformat(ts or datetime.utcnow()) or datetime.utcnow().isoformat() + "Z"
+
+
+def _load_state() -> dict[str, Any]:
+    try:
+        with STATE_PATH.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return {"users": {}, "jobs": {}, "flights": {}, "telemetry": {}}
+    except json.JSONDecodeError:
+        return {"users": {}, "jobs": {}, "flights": {}, "telemetry": {}}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = STATE_PATH.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(state, fh, indent=2, sort_keys=True)
+    tmp_path.replace(STATE_PATH)
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def _validate_email(value: str) -> str:
+    normalized = _normalize_email(value)
+    if "@" not in normalized:
+        raise ValueError("Email must include '@'")
+    local, domain = normalized.rsplit("@", 1)
+    if not local or not domain:
+        raise ValueError("Invalid email address")
+    if "." not in domain and domain not in {"localhost"}:
+        raise ValueError("Email domain must include a dot")
+    return normalized
+
+
+EmailAddress = Annotated[str, AfterValidator(_validate_email)]
+
+
+def _hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    iterations = 120_000
+    derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return f"pbkdf2_sha256${iterations}${salt.hex()}${derived.hex()}"
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    try:
+        algorithm, iteration_str, salt_hex, hash_hex = stored.split("$", 3)
+    except ValueError:
+        return False
+    if algorithm != "pbkdf2_sha256":
+        return False
+    try:
+        iterations = int(iteration_str)
+        salt = bytes.fromhex(salt_hex)
+        expected = bytes.fromhex(hash_hex)
+    except (ValueError, TypeError):
+        return False
+    candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    return secrets.compare_digest(candidate, expected)
+
+
+@contextmanager
+def _session():
+    if not USE_DB:
+        raise RuntimeError("Database not configured")
+    session_factory = getattr(db_module, "SessionLocal", None)
+    if session_factory is None:
+        raise RuntimeError("Session factory unavailable")
+    session = session_factory()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def _serialize_point(point: Any) -> dict[str, Any]:
+    if isinstance(point, dict):
+        return {
+            "flight_id": point["flight_id"],
+            "k": point["k"],
+            "lat": point["lat"],
+            "lon": point["lon"],
+            "alt": point.get("alt", 0.0),
+            "ts": point.get("ts"),
+        }
+    ts = _isoformat(getattr(point, "ts", None))
+    return {
+        "flight_id": point.flight_id,
+        "k": point.k,
+        "lat": point.lat,
+        "lon": point.lon,
+        "alt": point.alt,
+        "ts": ts,
+    }
+
+
+def _serialize_job(job: Any) -> dict[str, Any]:
+    def _status(assignee: str | None) -> str:
+        return "claimed" if assignee else "open"
+
+    if isinstance(job, dict):
+        legs = job.get("legs") or []
+        assigned_to = job.get("assigned_to")
+        if assigned_to:
+            assigned_to = _normalize_email(str(assigned_to))
+        created_by = job.get("created_by")
+        if created_by:
+            created_by = _normalize_email(str(created_by))
+
+        data = {
+            "job_id": job.get("job_id"),
+            "title": job.get("title"),
+            "platform": job.get("platform"),
+            "payload": job.get("payload"),
+            "weight_lbs": job.get("weight_lbs"),
+            "departure_airport": job.get("departure_airport"),
+            "arrival_airport": job.get("arrival_airport"),
+            "deadline": job.get("deadline"),
+            "notes": job.get("notes"),
+            "created_at": job.get("created_at"),
+            "created_by": created_by,
+            "assigned_to": assigned_to,
+            "legs": legs,
+        }
+        data["status"] = _status(assigned_to)
+        return data
+
+    legs: list[dict[str, Any]] = []
+    for leg in getattr(job, "legs", []) or []:
+        legs.append({"seq": getattr(leg, "seq", 0), "mode": getattr(leg, "mode", "")})
+
+    detail = getattr(job, "detail", None)
+    created_by = getattr(detail, "created_by", None) if detail is not None else getattr(job, "created_by", None)
+    if created_by:
+        created_by = _normalize_email(str(created_by))
+
+    assigned_to = None
+    if detail is not None:
+        assigned_to = getattr(detail, "assigned_to", None)
+    owner = getattr(job, "owner", None)
+    if owner is not None and getattr(owner, "email", None):
+        assigned_to = getattr(owner, "email")
+    if assigned_to:
+        assigned_to = _normalize_email(str(assigned_to))
+
+    created_at_source = getattr(detail, "created_at", None) if detail is not None else getattr(job, "created_at", None)
+
+    return {
+        "job_id": getattr(job, "job_id", None),
+        "title": getattr(detail, "title", None) if detail is not None else getattr(job, "title", None),
+        "platform": getattr(detail, "platform", None) if detail is not None else getattr(job, "platform", None),
+        "payload": getattr(detail, "payload", None) if detail is not None else getattr(job, "payload", None),
+        "weight_lbs": getattr(detail, "weight_lbs", None) if detail is not None else getattr(job, "weight_lbs", None),
+        "departure_airport": getattr(detail, "departure_airport", None) if detail is not None else getattr(job, "departure_airport", None),
+        "arrival_airport": getattr(detail, "arrival_airport", None) if detail is not None else getattr(job, "arrival_airport", None),
+        "deadline": _isoformat(getattr(detail, "deadline", None)) if detail is not None else _isoformat(getattr(job, "deadline", None)),
+        "notes": getattr(detail, "notes", None) if detail is not None else getattr(job, "notes", None),
+        "created_at": _isoformat(created_at_source),
+        "created_by": created_by,
+        "assigned_to": assigned_to,
+        "status": _status(assigned_to),
+        "legs": legs,
+    }
+
+
+def _persist_job(
+    *,
+    job_id: str,
+    creator_email: str,
+    created_at: datetime,
+    title: str,
+    platform: str,
+    payload_desc: str,
+    weight_lbs: float | None,
+    departure_airport: str,
+    arrival_airport: str,
+    deadline: datetime | None,
+    notes: str | None,
+    legs: list[dict[str, Any]],
+    assigned_to: str | None = None,
+) -> dict[str, Any]:
+    """Persist a job in either the database or JSON fallback store."""
+
+    normalized_creator = _normalize_email(creator_email)
+    normalized_assignee = _normalize_email(assigned_to) if assigned_to else None
+    departure = departure_airport.upper()
+    arrival = arrival_airport.upper()
+    deadline_dt = deadline
+    if isinstance(deadline_dt, datetime) and deadline_dt.tzinfo is not None:
+        deadline_dt = deadline_dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+    if USE_DB:
+        with _session() as session:
+            job = db_module.Job(job_id=job_id)
+            session.add(job)
+
+            detail_model = None
+            if hasattr(db_module, "JobDetail"):
+                detail_model = db_module.JobDetail(
+                    job_id=job_id,
+                    title=title,
+                    platform=platform,
+                    payload=payload_desc,
+                    weight_lbs=weight_lbs,
+                    departure_airport=departure,
+                    arrival_airport=arrival,
+                    deadline=deadline_dt,
+                    notes=notes,
+                    created_by=normalized_creator,
+                    created_at=created_at,
+                    assigned_to=normalized_assignee,
+                )
+                job.detail = detail_model
+                session.add(detail_model)
+
+            if normalized_assignee and hasattr(db_module, "JobOwner"):
+                existing_owner = job.owner
+                if existing_owner is None:
+                    job.owner = db_module.JobOwner(job_id=job_id, email=normalized_assignee)
+                else:
+                    existing_owner.email = normalized_assignee
+
+            for leg in legs or []:
+                leg_model = db_module.Leg(
+                    job=job,
+                    seq=int(leg.get("seq", 1) or 1),
+                    mode=str(leg.get("mode", "flight") or "flight"),
+                )
+                session.add(leg_model)
+
+            session.flush()
+            session.refresh(job)
+            return _serialize_job(job)
+
+    state = _load_state()
+    jobs = state.setdefault("jobs", {})
+    job_entry = {
+        "job_id": job_id,
+        "title": title,
+        "platform": platform,
+        "payload": payload_desc,
+        "weight_lbs": weight_lbs,
+        "departure_airport": departure,
+        "arrival_airport": arrival,
+        "deadline": _isoformat(deadline),
+        "notes": notes,
+        "created_at": _isoformat(created_at),
+        "created_by": normalized_creator,
+        "assigned_to": normalized_assignee,
+        "legs": legs or [],
+    }
+    jobs[job_id] = job_entry
+    _save_state(state)
+    return _serialize_job(job_entry)
+
+
+def _resolve_weight(weight_spec: Any) -> float:
+    """Convert a mission weight specification into a concrete pound value."""
+
+    default_low, default_high = 3000.0, 6500.0
+
+    if isinstance(weight_spec, tuple) and len(weight_spec) == 2:
+        low, high = weight_spec
+        try:
+            low_f = float(low)
+            high_f = float(high)
+        except (TypeError, ValueError):
+            low_f, high_f = default_low, default_high
+    elif isinstance(weight_spec, (int, float)):
+        low_f = high_f = float(weight_spec)
+    else:
+        low_f, high_f = default_low, default_high
+
+    if high_f < low_f:
+        low_f, high_f = high_f, low_f
+
+    if low_f == high_f:
+        return round(low_f, 1)
+
+    return round(random.uniform(low_f, high_f), 1)
+
+
+def _resolve_deadline(now: datetime, hours_spec: Any) -> datetime:
+    """Resolve a deadline relative to *now* using an hours specification."""
+
+    default_range = (4, 12)
+    if isinstance(hours_spec, tuple) and len(hours_spec) == 2:
+        start, end = hours_spec
+        try:
+            start_i = int(start)
+            end_i = int(end)
+        except (TypeError, ValueError):
+            start_i, end_i = default_range
+    elif isinstance(hours_spec, (int, float)):
+        start_i = end_i = int(hours_spec)
+    else:
+        start_i, end_i = default_range
+
+    if end_i < start_i:
+        start_i, end_i = end_i, start_i
+
+    if start_i == end_i:
+        offset = start_i
+    else:
+        offset = random.randint(start_i, end_i)
+
+    offset = max(1, offset)
+    return now + timedelta(hours=offset)
+
+
+def _build_simunet_job(now: datetime | None = None) -> dict[str, Any]:
+    """Create a randomized Microsoft Flight Simulator job blueprint."""
+
+    current = now or datetime.utcnow()
+    mission = random.choice(MSFS_MISSIONS)
+
+    weight_value = _resolve_weight(mission.get("weight_lbs"))
+    deadline = _resolve_deadline(current, mission.get("deadline_hours"))
+
+    base_notes = mission.get("notes") or ""
+    extra_note = "SimuNet Mission Control auto-generated assignment."
+    notes = f"{base_notes}\n\n{extra_note}" if base_notes else extra_note
+
+    legs = [dict(leg) for leg in MSFS_DEFAULT_LEGS]
+
+    return {
+        "title": mission.get("title", "Microsoft Flight Simulator Job"),
+        "platform": "Microsoft Flight Simulator",
+        "payload": mission.get("payload", "Logistics payload"),
+        "weight_lbs": weight_value,
+        "departure_airport": mission.get("departure", "KSEA"),
+        "arrival_airport": mission.get("arrival", "CYVR"),
+        "deadline": deadline,
+        "notes": notes,
+        "legs": legs,
+    }
+
+
+def _serialize_user(user: Any) -> dict[str, Any]:
+    if isinstance(user, dict):
+        email_value = user.get("email")
+        normalized_email = _normalize_email(str(email_value)) if email_value else None
+        is_admin_value = user.get("is_admin")
+        if is_admin_value is None and normalized_email:
+            is_admin_value = normalized_email == SIMUNET_CREATOR_EMAIL
+        return {
+            "id": user.get("id"),
+            "email": email_value,
+            "created_at": user.get("created_at"),
+            "is_admin": bool(is_admin_value),
+        }
+
+    email_value = getattr(user, "email", None)
+    normalized_email = _normalize_email(str(email_value)) if email_value else None
+    is_admin_value = getattr(user, "is_admin", None)
+    if is_admin_value is None and normalized_email:
+        is_admin_value = normalized_email == SIMUNET_CREATOR_EMAIL
+
+    return {
+        "id": getattr(user, "id", None),
+        "email": email_value,
+        "created_at": _isoformat(getattr(user, "created_at", None)),
+        "is_admin": bool(is_admin_value),
+    }
+
+
+def _user_is_admin(user: Any, email: str | None = None) -> bool:
+    if isinstance(user, dict):
+        flag = user.get("is_admin")
+        if flag is not None:
+            return bool(flag)
+        candidate = user.get("email")
+        if candidate:
+            return _normalize_email(str(candidate)) == SIMUNET_CREATOR_EMAIL
+        if email:
+            return _normalize_email(email) == SIMUNET_CREATOR_EMAIL
+        return False
+
+    attr = getattr(user, "is_admin", None)
+    if attr is not None:
+        return bool(attr)
+
+    candidate = email or getattr(user, "email", None)
+    if candidate:
+        return _normalize_email(str(candidate)) == SIMUNET_CREATOR_EMAIL
+    return False
+
+
+def _require_admin(actor_email: str | None) -> str:
+    if not actor_email:
+        raise HTTPException(status_code=401, detail="Admin privileges required")
+
+    normalized = _normalize_email(str(actor_email))
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=normalized).one_or_none()
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            if not _user_is_admin(user, normalized):
+                raise HTTPException(status_code=403, detail="Admin privileges required")
+    else:
+        state = _load_state()
+        users = state.setdefault("users", {})
+        user = users.get(normalized)
+        if user is None:
+            raise HTTPException(status_code=404, detail="User not found")
+        if not _user_is_admin(user, normalized):
+            raise HTTPException(status_code=403, detail="Admin privileges required")
+
+    return normalized
+
+
+def _count_admins_db(session: Any) -> int:
+    if not USE_DB:
+        return 0
+    user_model = getattr(db_module, "User", None)
+    if user_model is None:
+        return 0
+    admin_attr = getattr(user_model, "is_admin", None)
+    if admin_attr is None:
+        return 0
+    return session.query(user_model).filter(admin_attr.is_(True)).count()
+
+
+def _count_admins_state(users: dict[str, Any]) -> int:
+    return sum(1 for email, data in users.items() if _user_is_admin(data, email))
+
+
+class TelemetryPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    flight_id: str = Field(..., min_length=1)
+    k: int = Field(..., ge=0)
+    lat: float
+    lon: float
+    alt: float = 0.0
+    ts: datetime | None = None
+
+
+class AuthPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailAddress = Field(..., min_length=3, max_length=320)
+    password: str = Field(..., min_length=8)
+
+
+class JobLegPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    seq: int = Field(1, ge=1)
+    mode: str = Field("flight", min_length=1, max_length=32)
+
+
+class JobCreatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(..., min_length=3, max_length=255)
+    platform: str = Field("Microsoft Flight Simulator", min_length=3, max_length=128)
+    payload: str = Field(..., min_length=3, max_length=255)
+    weight_lbs: float | None = Field(default=None, ge=0)
+    departure_airport: str = Field(..., min_length=3, max_length=16)
+    arrival_airport: str = Field(..., min_length=3, max_length=16)
+    deadline: datetime
+    notes: str | None = Field(default=None, max_length=600)
+    created_by: EmailAddress = Field(..., min_length=3, max_length=320)
+    assigned_to: EmailAddress | None = Field(default=None, min_length=3, max_length=320)
+    legs: list[JobLegPayload] = Field(default_factory=list)
+
+
+class JobAutoPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    count: int = Field(default=1, ge=1, le=10)
+
+
+class JobClaimPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: EmailAddress = Field(..., min_length=3, max_length=320)
+
+
+class ReseedPayload(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    email: EmailAddress | None = Field(default=None, min_length=3, max_length=320)
+
+
+class AdminUserUpdatePayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    is_admin: bool | None = None
+    password: str | None = Field(default=None, min_length=8)
+
+
 FRONTEND_DIR = os.getenv(
     "SIMUNET_FRONTEND_DIR",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontend"))
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontend")),
 )
 
 assets_dir = os.path.join(FRONTEND_DIR, "assets")
 if os.path.isdir(assets_dir):
     app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
 
-@app.get("/", include_in_schema=False)
-def serve_index():
-    index = os.path.join(FRONTEND_DIR, "index.html")
-    if not os.path.exists(index):
-        return {"ok": True, "db": DB_AVAILABLE, "hint": "Place frontend in /app/frontend or set SIMUNET_FRONTEND_DIR"}
-    return FileResponse(index)
 
-@app.get("/favicon.ico", include_in_schema=False)
-def favicon():
-    path = os.path.join(FRONTEND_DIR, "favicon.ico")
-    if os.path.exists(path):
-        return FileResponse(path)
-    raise HTTPException(status_code=404)
-
-# SPA fallback: serve index.html for unknown non-API paths
-@app.get("/{full_path:path}", include_in_schema=False)
-def spa_fallback(full_path: str):
-    first = (full_path or "").split("/", 1)[0]
-    if first in {"status","dev","flights","telemetry","auth","docs","openapi.json"}:
-        # let FastAPI handle real API/docs routes
-        raise HTTPException(status_code=404)
-    candidate = os.path.join(FRONTEND_DIR, full_path)
-    if os.path.isfile(candidate):
-        return FileResponse(candidate)
-    index = os.path.join(FRONTEND_DIR, "index.html")
-    if os.path.exists(index):
-        return FileResponse(index)
-    raise HTTPException(status_code=404)
+@app.get("/status")
+def get_status() -> dict[str, object]:
+    """Simple health endpoint used by the frontend and smoke tests."""
+    return {"ok": True, "db": DB_AVAILABLE, "error": DB_ERROR}
 
 
-# Where the built/static frontend lives (we’ll copy it into the container at /app/frontend)
-FRONTEND_DIR = os.getenv(
-    "SIMUNET_FRONTEND_DIR",
-    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "frontend"))
-)
+@app.post("/auth/register", status_code=status.HTTP_201_CREATED)
+def register(payload: AuthPayload) -> dict[str, Any]:
+    email = _normalize_email(payload.email)
+    password = payload.password
 
-# Serve /assets/* straight from disk (icons, images, etc.)
-assets_dir = os.path.join(FRONTEND_DIR, "assets")
-if os.path.isdir(assets_dir):
-    app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+    if USE_DB:
+        with _session() as session:
+            existing = session.query(db_module.User).filter_by(email=email).one_or_none()
+            if existing:
+                raise HTTPException(status_code=409, detail="Email already registered")
+            is_admin = email == SIMUNET_CREATOR_EMAIL
+            if not is_admin and hasattr(db_module.User, "is_admin"):
+                is_admin = _count_admins_db(session) == 0
 
-@app.get("/", include_in_schema=False)
-def serve_index():
-    index = os.path.join(FRONTEND_DIR, "index.html")
-    if not os.path.exists(index):
-        # still show something useful if the file isn’t there yet
-        return {"ok": True, "db": DB_AVAILABLE, "hint": "Place frontend in /app/frontend or set SIMUNET_FRONTEND_DIR"}
-    return FileResponse(index)
+            user_kwargs = {
+                "email": email,
+                "hashed_password": _hash_password(password),
+                "created_at": datetime.utcnow(),
+            }
+            if hasattr(db_module.User, "is_admin"):
+                user_kwargs["is_admin"] = bool(is_admin)
 
-@app.get("/favicon.ico", include_in_schema=False)
-def favicon():
-    path = os.path.join(FRONTEND_DIR, "favicon.ico")
-    if os.path.exists(path):
-        return FileResponse(path)
-    raise HTTPException(status_code=404)
-@app.get("/{full_path:path}", include_in_schema=False)
-def spa_fallback(full_path: str):
-    # Don't intercept known API/doc routes
-    first = (full_path or "").split("/", 1)[0]
-    if first in {"status", "dev", "flights", "telemetry", "auth", "docs", "openapi.json"}:
-        raise HTTPException(status_code=404)
+            user = db_module.User(**user_kwargs)
+            session.add(user)
+            session.flush()
+            return {"ok": True, "user": _serialize_user(user)}
 
-    # Serve a real file if it exists (e.g., /assets/logo.svg), else serve index.html
-    candidate = os.path.join(FRONTEND_DIR, full_path)
-    if os.path.isfile(candidate):
-        return FileResponse(candidate)
-    index = os.path.join(FRONTEND_DIR, "index.html")
-    if os.path.exists(index):
-        return FileResponse(index)
-    raise HTTPException(status_code=404)
+    state = _load_state()
+    users = state.setdefault("users", {})
+    if email in users:
+        raise HTTPException(status_code=409, detail="Email already registered")
+    created_at = _now_iso()
+    user_id = uuid.uuid4().hex[:12]
+    is_admin = email == SIMUNET_CREATOR_EMAIL or _count_admins_state(users) == 0
+    users[email] = {
+        "id": user_id,
+        "email": email,
+        "hashed_password": _hash_password(password),
+        "created_at": created_at,
+        "is_admin": bool(is_admin),
+    }
+    _save_state(state)
+    return {"ok": True, "user": _serialize_user(users[email])}
+
+
+@app.post("/auth/login")
+def login(payload: AuthPayload) -> dict[str, Any]:
+    email = _normalize_email(payload.email)
+    password = payload.password
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=email).one_or_none()
+            if user is None or not _verify_password(password, user.hashed_password):
+                raise HTTPException(status_code=401, detail="Invalid credentials")
+            if getattr(user, "created_at", None) is None:
+                user.created_at = datetime.utcnow()
+                session.flush()
+            if email == SIMUNET_CREATOR_EMAIL and hasattr(user, "is_admin") and not _user_is_admin(user, email):
+                user.is_admin = True  # type: ignore[assignment]
+                session.flush()
+            return {"ok": True, "user": _serialize_user(user)}
+
+    state = _load_state()
+    users = state.setdefault("users", {})
+    stored = users.get(email)
+    if not stored or not _verify_password(password, stored.get("hashed_password", "")):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    if "is_admin" not in stored:
+        stored["is_admin"] = _user_is_admin(stored, email)
+        users[email] = stored
+        _save_state(state)
+    return {"ok": True, "user": _serialize_user(stored)}
+
+
+@app.post("/dev/reseed", status_code=status.HTTP_201_CREATED)
+def reseed(payload: ReseedPayload | None = None) -> dict[str, Any]:
+    """Create a demo job/assignment for quickstarts."""
+    job_id = uuid.uuid4().hex[:12]
+    created_at = datetime.utcnow()
+    legs = [
+        {"seq": 1, "mode": "flight"},
+    ]
+
+    owner_email = None
+    if payload and payload.email:
+        owner_email = _normalize_email(str(payload.email))
+
+    if owner_email:
+        if USE_DB:
+            with _session() as session:
+                user = (
+                    session.query(db_module.User)
+                    .filter_by(email=owner_email)
+                    .one_or_none()
+                )
+                if user is None:
+                    raise HTTPException(status_code=404, detail="User not found")
+        else:
+            state = _load_state()
+            users = state.setdefault("users", {})
+            if owner_email not in users:
+                raise HTTPException(status_code=404, detail="User not found")
+
+    job_data = _persist_job(
+        job_id=job_id,
+        creator_email=owner_email or SIMUNET_CREATOR_EMAIL,
+        created_at=created_at,
+        title="MSFS Relief Flight",
+        platform="Microsoft Flight Simulator",
+        payload_desc="Emergency medical supplies",
+        weight_lbs=7200.0,
+        departure_airport="KSEA",
+        arrival_airport="CYVR",
+        deadline=created_at + timedelta(hours=6),
+        notes="Deliver the payload before the deadline to keep regional hospitals stocked.",
+        legs=legs,
+        assigned_to=owner_email,
+    )
+
+    return {
+        "ok": True,
+        "job_id": job_data.get("job_id"),
+        "job": job_data,
+    }
+
+
+@app.post("/jobs", status_code=status.HTTP_201_CREATED)
+def create_job(payload: JobCreatePayload) -> dict[str, Any]:
+    """Create a new Microsoft Flight Simulator job."""
+
+    creator_email = _normalize_email(str(payload.created_by))
+    assignee_email = _normalize_email(str(payload.assigned_to)) if payload.assigned_to else None
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=creator_email).one_or_none()
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+            if assignee_email:
+                assignee = session.query(db_module.User).filter_by(email=assignee_email).one_or_none()
+                if assignee is None:
+                    raise HTTPException(status_code=404, detail="Assignee not found")
+    else:
+        state = _load_state()
+        users = state.setdefault("users", {})
+        if creator_email not in users:
+            raise HTTPException(status_code=404, detail="User not found")
+        if assignee_email and assignee_email not in users:
+            raise HTTPException(status_code=404, detail="Assignee not found")
+
+    legs = [
+        {"seq": leg.seq, "mode": leg.mode}
+        for leg in (payload.legs or [])
+    ]
+    if not legs:
+        legs = [{"seq": 1, "mode": "flight"}]
+
+    job_id = uuid.uuid4().hex[:12]
+    created_at = datetime.utcnow()
+
+    job_data = _persist_job(
+        job_id=job_id,
+        creator_email=creator_email,
+        created_at=created_at,
+        title=payload.title.strip(),
+        platform=payload.platform.strip(),
+        payload_desc=payload.payload.strip(),
+        weight_lbs=payload.weight_lbs,
+        departure_airport=payload.departure_airport.strip(),
+        arrival_airport=payload.arrival_airport.strip(),
+        deadline=payload.deadline,
+        notes=payload.notes.strip() if payload.notes else None,
+        legs=legs,
+        assigned_to=assignee_email,
+    )
+
+    return {"ok": True, "job": job_data}
+
+
+@app.post("/jobs/generate", status_code=status.HTTP_201_CREATED)
+def auto_generate_jobs(payload: JobAutoPayload | None = None) -> dict[str, Any]:
+    """Create SimuNet-authored jobs without manual input."""
+
+    count = 1
+    if payload is not None:
+        count = int(payload.count)
+
+    created_jobs: list[dict[str, Any]] = []
+    for _ in range(count):
+        job_id = uuid.uuid4().hex[:12]
+        created_at = datetime.utcnow()
+        blueprint = _build_simunet_job(created_at)
+        job = _persist_job(
+            job_id=job_id,
+            creator_email=SIMUNET_CREATOR_EMAIL,
+            created_at=created_at,
+            title=blueprint["title"],
+            platform=blueprint["platform"],
+            payload_desc=blueprint["payload"],
+            weight_lbs=blueprint["weight_lbs"],
+            departure_airport=blueprint["departure_airport"],
+            arrival_airport=blueprint["arrival_airport"],
+            deadline=blueprint["deadline"],
+            notes=blueprint["notes"],
+            legs=blueprint["legs"],
+            assigned_to=None,
+        )
+        created_jobs.append(job)
+
+    return {"ok": True, "jobs": created_jobs, "count": len(created_jobs)}
+
+
+@app.post("/jobs/{job_id}/claim")
+def claim_job(job_id: str, payload: JobClaimPayload) -> dict[str, Any]:
+    """Assign a job to a specific user."""
+
+    claimer = _normalize_email(str(payload.email))
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=claimer).one_or_none()
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+
+            job = session.query(db_module.Job).filter_by(job_id=job_id).one_or_none()
+            if job is None:
+                raise HTTPException(status_code=404, detail="Job not found")
+
+            existing_assignee = None
+            owner_cls = getattr(db_module, "JobOwner", None)
+            if owner_cls is not None and job.owner is not None:
+                existing_assignee = _normalize_email(str(job.owner.email))
+
+            detail_model = getattr(job, "detail", None)
+            if existing_assignee is None and detail_model is not None and getattr(detail_model, "assigned_to", None):
+                existing_assignee = _normalize_email(str(detail_model.assigned_to))
+
+            if existing_assignee and existing_assignee != claimer:
+                raise HTTPException(status_code=409, detail="Job already claimed")
+
+            if owner_cls is not None:
+                if job.owner is None:
+                    job.owner = owner_cls(job_id=job_id, email=claimer)
+                else:
+                    job.owner.email = claimer
+
+            if detail_model is not None:
+                detail_model.assigned_to = claimer
+            elif hasattr(db_module, "JobDetail"):
+                detail_cls = getattr(db_module, "JobDetail")
+                existing_detail = session.query(detail_cls).filter_by(job_id=job_id).one_or_none()
+                if existing_detail is not None:
+                    existing_detail.assigned_to = claimer
+
+            session.flush()
+            session.refresh(job)
+            return {"ok": True, "job": _serialize_job(job)}
+
+    state = _load_state()
+    users = state.setdefault("users", {})
+    if claimer not in users:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    jobs = state.setdefault("jobs", {})
+    job_entry = jobs.get(job_id)
+    if not job_entry:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    existing_assignee = job_entry.get("assigned_to")
+    if existing_assignee:
+        existing_assignee_norm = _normalize_email(str(existing_assignee))
+        if existing_assignee_norm and existing_assignee_norm != claimer:
+            raise HTTPException(status_code=409, detail="Job already claimed")
+
+    job_entry["assigned_to"] = claimer
+    jobs[job_id] = job_entry
+    _save_state(state)
+    return {"ok": True, "job": _serialize_job(job_entry)}
+
+
+@app.get("/jobs")
+def list_jobs(email: EmailAddress | None = Query(default=None)) -> dict[str, Any]:
+    """Return available jobs and the caller's claimed jobs."""
+
+    filter_email = _normalize_email(str(email)) if email else None
+    available: list[dict[str, Any]] = []
+    mine: list[dict[str, Any]] = []
+
+    def _sort_key(item: dict[str, Any]) -> tuple[str, str]:
+        deadline = item.get("deadline") or ""
+        created = item.get("created_at") or ""
+        return (deadline or "", created or "")
+
+    if USE_DB:
+        with _session() as session:
+            query = session.query(db_module.Job)
+            if joinedload is not None:
+                query = query.options(joinedload(db_module.Job.legs))
+                if hasattr(db_module, "JobOwner"):
+                    query = query.options(joinedload(db_module.Job.owner))
+                if hasattr(db_module, "JobDetail"):
+                    query = query.options(joinedload(db_module.Job.detail))
+
+            jobs = query.order_by(db_module.Job.job_id.desc()).all()
+            for job in jobs:
+                serialized = _serialize_job(job)
+                assignee = serialized.get("assigned_to")
+                if assignee:
+                    if filter_email and assignee == filter_email:
+                        mine.append(serialized)
+                    continue
+                available.append(serialized)
+    else:
+        state = _load_state()
+        stored = state.get("jobs", {})
+        for job in stored.values():
+            serialized = _serialize_job(job)
+            assignee = serialized.get("assigned_to")
+            if assignee:
+                if filter_email and assignee == filter_email:
+                    mine.append(serialized)
+                continue
+            available.append(serialized)
+
+    available.sort(key=_sort_key)
+    mine.sort(key=_sort_key)
+
+    response = {"available": available, "mine": mine if filter_email else []}
+    return response
+
+
+@app.get("/admin/jobs")
+def admin_list_jobs(actor: EmailAddress = Query(..., alias="actor")) -> dict[str, Any]:
+    """Return every job for administrator dashboards."""
+
+    _require_admin(str(actor))
+
+    jobs: list[dict[str, Any]] = []
+    if USE_DB:
+        with _session() as session:
+            query = session.query(db_module.Job)
+            if joinedload is not None:
+                query = query.options(joinedload(db_module.Job.legs))
+                if hasattr(db_module, "JobOwner"):
+                    query = query.options(joinedload(db_module.Job.owner))
+                if hasattr(db_module, "JobDetail"):
+                    query = query.options(joinedload(db_module.Job.detail))
+            records = query.order_by(db_module.Job.job_id.desc()).all()
+            jobs = [_serialize_job(job) for job in records]
+    else:
+        state = _load_state()
+        stored = state.get("jobs", {})
+        jobs = [_serialize_job(job) for job in stored.values()]
+    jobs.sort(key=lambda item: (item.get("created_at") or "", item.get("job_id") or ""), reverse=True)
+    return {"ok": True, "jobs": jobs}
+
+
+@app.delete("/admin/jobs/{job_id}")
+def admin_delete_job(job_id: str, actor: EmailAddress = Query(..., alias="actor")) -> dict[str, Any]:
+    """Delete a job regardless of claim status."""
+
+    _require_admin(str(actor))
+
+    if USE_DB:
+        with _session() as session:
+            job = session.query(db_module.Job).filter_by(job_id=job_id).one_or_none()
+            if job is None:
+                raise HTTPException(status_code=404, detail="Job not found")
+            session.delete(job)
+            session.flush()
+            return {"ok": True, "job_id": job_id}
+
+    state = _load_state()
+    jobs = state.setdefault("jobs", {})
+    job_entry = jobs.pop(job_id, None)
+    if job_entry is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    _save_state(state)
+    return {"ok": True, "job_id": job_id, "job": _serialize_job(job_entry)}
+
+
+@app.get("/admin/users")
+def admin_list_users(actor: EmailAddress = Query(..., alias="actor")) -> dict[str, Any]:
+    """Return all user profiles."""
+
+    _require_admin(str(actor))
+
+    if USE_DB:
+        with _session() as session:
+            records = (
+                session.query(db_module.User)
+                .order_by(db_module.User.email.asc())
+                .all()
+            )
+            users = [_serialize_user(record) for record in records]
+            return {"ok": True, "users": users}
+
+    state = _load_state()
+    stored_users = state.get("users", {})
+    users = []
+    for email, data in sorted(stored_users.items()):
+        if "email" not in data:
+            data = dict(data)
+            data["email"] = email
+        users.append(_serialize_user(data))
+    return {"ok": True, "users": users}
+
+
+@app.patch("/admin/users/{email}")
+def admin_update_user(
+    email: str,
+    payload: AdminUserUpdatePayload,
+    actor: EmailAddress = Query(..., alias="actor"),
+) -> dict[str, Any]:
+    """Update admin status or password for a user profile."""
+
+    actor_email = _require_admin(str(actor))
+    target_email = _normalize_email(email)
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=target_email).one_or_none()
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+
+            updated = False
+            if payload.is_admin is not None and hasattr(user, "is_admin"):
+                desired = bool(payload.is_admin)
+                current_admin = _user_is_admin(user, target_email)
+                if desired != current_admin:
+                    if not desired and _count_admins_db(session) <= 1 and current_admin:
+                        raise HTTPException(status_code=400, detail="Cannot remove last admin")
+                    user.is_admin = desired  # type: ignore[assignment]
+                    updated = True
+
+            if payload.password:
+                user.hashed_password = _hash_password(payload.password)
+                updated = True
+
+            if updated:
+                session.flush()
+
+            return {"ok": True, "user": _serialize_user(user)}
+
+    state = _load_state()
+    users = state.setdefault("users", {})
+    user = users.get(target_email)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    updated = False
+    if payload.is_admin is not None:
+        desired = bool(payload.is_admin)
+        current_admin = _user_is_admin(user, target_email)
+        if desired != current_admin:
+            if not desired and _count_admins_state(users) <= 1 and current_admin:
+                raise HTTPException(status_code=400, detail="Cannot remove last admin")
+            user["is_admin"] = desired
+            updated = True
+
+    if payload.password:
+        user["hashed_password"] = _hash_password(payload.password)
+        updated = True
+
+    if updated:
+        users[target_email] = user
+        _save_state(state)
+
+    return {"ok": True, "user": _serialize_user(user)}
+
+
+@app.delete("/admin/users/{email}")
+def admin_delete_user(email: str, actor: EmailAddress = Query(..., alias="actor")) -> dict[str, Any]:
+    """Remove a user account and release related assignments."""
+
+    actor_email = _require_admin(str(actor))
+    target_email = _normalize_email(email)
+
+    if USE_DB:
+        with _session() as session:
+            user = session.query(db_module.User).filter_by(email=target_email).one_or_none()
+            if user is None:
+                raise HTTPException(status_code=404, detail="User not found")
+
+            if _user_is_admin(user, target_email) and _count_admins_db(session) <= 1:
+                raise HTTPException(status_code=400, detail="Cannot remove last admin")
+
+            owner_cls = getattr(db_module, "JobOwner", None)
+            if owner_cls is not None:
+                owners = session.query(owner_cls).filter_by(email=target_email).all()
+                for owner in owners:
+                    session.delete(owner)
+
+            detail_cls = getattr(db_module, "JobDetail", None)
+            if detail_cls is not None:
+                details = session.query(detail_cls).filter_by(assigned_to=target_email).all()
+                for detail in details:
+                    detail.assigned_to = None
+
+            session.delete(user)
+            session.flush()
+
+            if target_email == actor_email:
+                return {"ok": True, "deleted": target_email, "self": True}
+            return {"ok": True, "deleted": target_email}
+
+    state = _load_state()
+    users = state.setdefault("users", {})
+    user = users.get(target_email)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if _user_is_admin(user, target_email) and _count_admins_state(users) <= 1:
+        raise HTTPException(status_code=400, detail="Cannot remove last admin")
+
+    users.pop(target_email, None)
+
+    jobs = state.setdefault("jobs", {})
+    for job in jobs.values():
+        assignee = job.get("assigned_to")
+        if assignee and _normalize_email(str(assignee)) == target_email:
+            job["assigned_to"] = None
+
+    _save_state(state)
+    return {"ok": True, "deleted": target_email}
+
+
+@app.post("/flights", status_code=status.HTTP_201_CREATED)
+def create_flight(
+    assignment_id: str = Query(..., min_length=1),
+    seq: int = Query(1, ge=1),
+    mode: str = Query("truck", min_length=1),
+) -> dict[str, Any]:
+    """Create a new flight for a given assignment."""
+
+    flight_id = uuid.uuid4().hex
+    if USE_DB:
+        with _session() as session:
+            session.add(
+                db_module.Flight(
+                    flight_id=flight_id,
+                    assignment_id=assignment_id,
+                    seq=seq,
+                    mode=mode,
+                )
+            )
+    else:
+        state = _load_state()
+        state.setdefault("flights", {})[flight_id] = {
+            "flight_id": flight_id,
+            "assignment_id": assignment_id,
+            "seq": seq,
+            "mode": mode,
+            "created_at": _now_iso(),
+        }
+        _save_state(state)
+
+    return {"ok": True, "flight_id": flight_id}
+
+
+@app.post("/telemetry", status_code=status.HTTP_202_ACCEPTED)
+def post_telemetry(payload: TelemetryPayload) -> dict[str, Any]:
+    """Store telemetry points for a flight."""
+
+    if USE_DB:
+        with _session() as session:
+            existing = (
+                session.query(db_module.Telemetry)
+                .filter_by(flight_id=payload.flight_id, k=payload.k)
+                .one_or_none()
+            )
+            if existing:
+                existing.lat = payload.lat
+                existing.lon = payload.lon
+                existing.alt = payload.alt
+                existing.ts = payload.ts
+            else:
+                session.add(
+                    db_module.Telemetry(
+                        flight_id=payload.flight_id,
+                        k=payload.k,
+                        lat=payload.lat,
+                        lon=payload.lon,
+                        alt=payload.alt,
+                        ts=payload.ts,
+                    )
+                )
+    else:
+        state = _load_state()
+        bucket = state.setdefault("telemetry", {}).setdefault(payload.flight_id, [])
+        new_point = {
+            "flight_id": payload.flight_id,
+            "k": payload.k,
+            "lat": payload.lat,
+            "lon": payload.lon,
+            "alt": payload.alt,
+            "ts": _isoformat(payload.ts),
+        }
+        replaced = False
+        for idx, point in enumerate(bucket):
+            if point.get("k") == payload.k:
+                bucket[idx] = new_point
+                replaced = True
+                break
+        if not replaced:
+            bucket.append(new_point)
+            bucket.sort(key=lambda item: item.get("k", 0))
+        _save_state(state)
+
+    return {"ok": True}
+
+
+@app.get("/telemetry/{flight_id}")
+def get_telemetry(flight_id: str) -> dict[str, Any]:
+    """Return stored telemetry for a flight."""
+
+    if USE_DB:
+        with _session() as session:
+            points = (
+                session.query(db_module.Telemetry)
+                .filter_by(flight_id=flight_id)
+                .order_by(db_module.Telemetry.k.asc())
+                .all()
+            )
+            serialized = [_serialize_point(p) for p in points]
+    else:
+        state = _load_state()
+        stored = state.get("telemetry", {}).get(flight_id, [])
+        serialized = [_serialize_point(p) for p in stored]
+
+    return {"flight_id": flight_id, "points": serialized}
 
 
 @app.get("/", include_in_schema=False)
 def home():
+    """Serve the SPA entrypoint if available, otherwise render a simple status page."""
+    index = os.path.join(FRONTEND_DIR, "index.html")
+    if os.path.exists(index):
+        return FileResponse(index)
+
     db_state = "online" if DB_AVAILABLE else "offline"
-    return HTMLResponse(f"""<!doctype html>
+    return HTMLResponse(
+        """<!doctype html>
 <html><head><meta charset="utf-8"><title>SimuNet API</title>
 <style>body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial;margin:2rem;color:#eaf2ff;background:#0b1020}
-a{color:#7bb1ff;text-decoration:none} .box{padding:1rem;border:1px solid #273469;border-radius:12px;background:#0f1430;max-width:680px}
-code{background:#0f1538;border:1px solid #273469;border-radius:6px;padding:2px 6px}</style></head>
+  a{color:#7bb1ff;text-decoration:none}
+  .box{padding:1rem;border:1px solid #273469;border-radius:12px;background:#0f1430;max-width:680px}
+  code{background:#0f1538;border:1px solid #273469;border-radius:6px;padding:2px 6px}
+</style></head>
 <body>
   <div class="box">
     <h1>SimuNet API</h1>
     <p>Status: <strong>{db_state}</strong></p>
     <p>Try: <a href="/status">/status</a> · <a href="/docs">/docs</a></p>
   </div>
-</body></html>""")
+</body></html>""".format(db_state=db_state)
+    )
 
+
+@app.get("/favicon.ico", include_in_schema=False)
+def favicon():
+    """Return the favicon if it exists on disk."""
+    path = os.path.join(FRONTEND_DIR, "favicon.ico")
+    if os.path.exists(path):
+        return FileResponse(path)
+    raise HTTPException(status_code=404)
+
+
+@app.get("/{full_path:path}", include_in_schema=False)
+def spa_fallback(full_path: str):
+    """Serve static assets or fall back to the SPA entrypoint."""
+    first = (full_path or "").split("/", 1)[0]
+    if first in {"status", "dev", "flights", "telemetry", "auth", "docs", "openapi.json"}:
+        raise HTTPException(status_code=404)
+
+    candidate = os.path.join(FRONTEND_DIR, full_path)
+    if os.path.isfile(candidate):
+        return FileResponse(candidate)
+
+    index = os.path.join(FRONTEND_DIR, "index.html")
+    if os.path.exists(index):
+        return FileResponse(index)
+
+    raise HTTPException(status_code=404)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,9 @@
         <div><div class="font-bold text-lg">SimuNet</div><div class="text-xs text-slate-400">Drive • Fly • Deliver</div></div>
       </div>
       <nav class="mt-4 flex-1 flex flex-col">
-        <a class="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/10 text-white" href="#"><i data-lucide="layout-dashboard" class="w-4 h-4"></i> Dashboard</a>
+        <a data-nav="dashboard" class="nav-link flex items-center gap-2 px-3 py-2 rounded-lg bg-white/10 text-white" href="#dashboard"><i data-lucide="layout-dashboard" class="w-4 h-4"></i> Dashboard</a>
+        <a data-nav="jobs" class="nav-link flex items-center gap-2 px-3 py-2 rounded-lg text-slate-300 hover:bg-white/10" href="#jobs"><i data-lucide="clipboard-list" class="w-4 h-4"></i> Jobs</a>
+        <a data-nav="admin" id="navAdmin" class="nav-link flex items-center gap-2 px-3 py-2 rounded-lg text-slate-300 hover:bg-white/10 hidden" href="#admin"><i data-lucide="shield-check" class="w-4 h-4"></i> Admin</a>
         <a class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-300 hover:bg-white/10" href="#"><i data-lucide="plane" class="w-4 h-4"></i> Flights</a>
         <a class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-300 hover:bg-white/10" href="#"><i data-lucide="radio" class="w-4 h-4"></i> Connectors</a>
         <a class="flex items-center gap-2 px-3 py-2 rounded-lg text-slate-300 hover:bg-white/10" href="#"><i data-lucide="book-open" class="w-4 h-4"></i> Docs</a>
@@ -34,87 +36,304 @@
 
     <div class="flex flex-col">
       <header class="flex items-center gap-3 p-3 md:p-4 border-b border-white/10 bg-[#0f1430]/90 sticky top-0 z-10">
-        <div class="hidden md:flex items-center gap-2">
-          <span class="text-xs px-2 py-1 border border-white/10 rounded-full text-slate-300">API</span>
-          <input id="api" class="px-3 py-2 w-[320px] rounded-lg bg-[#0f1538] border border-white/10 text-sm" placeholder="https://your-api.onrender.com" />
-          <button id="btnPing" class="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm">Ping</button>
-          <span id="dbStatus" class="text-xs px-2 py-1 rounded-full border border-white/10 text-slate-300">db?</span>
-          <span id="apiStatus" class="text-xs px-2 py-1 rounded-full border border-white/10 text-slate-300">api?</span>
+        <div class="flex items-center gap-2 text-xs">
+          <span id="dbStatus" class="px-2 py-1 rounded-full border border-white/10 text-slate-300">db?</span>
+          <span id="apiStatus" class="px-2 py-1 rounded-full border border-white/10 text-slate-300">api?</span>
         </div>
         <div class="ml-auto flex items-center gap-3">
           <button id="themeToggle" class="p-2 rounded-lg bg-white/10" title="Toggle theme"><i data-lucide="sun"></i></button>
-          <div class="flex items-center gap-2 px-2 py-1 rounded-lg bg-white/10">
-            <div class="w-6 h-6 rounded-full grad grid place-items-center text-xs font-bold">A</div>
-            <div class="hidden sm:block text-xs text-slate-300">Logged in</div>
-          </div>
+          <button id="btnAccount" class="flex items-center gap-2 px-2 py-1 rounded-lg bg-white/10 hover:bg-white/15 focus:outline-none focus:ring-2 focus:ring-white/30" type="button">
+            <div id="accountAvatar" class="w-7 h-7 rounded-full grad grid place-items-center text-xs font-bold">?</div>
+            <div id="accountLabel" class="hidden sm:block text-xs text-slate-300">Sign in</div>
+          </button>
         </div>
       </header>
 
       <main class="p-3 md:p-6 space-y-6">
-        <section class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
-            <div class="text-slate-300 text-sm">Active Flights</div>
-            <div class="text-2xl font-bold mt-1"><span id="kpiFlights">0</span></div>
+        <section data-page="dashboard" class="space-y-6">
+          <section class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
+              <div class="text-slate-300 text-sm">Active Flights</div>
+              <div class="text-2xl font-bold mt-1"><span id="kpiFlights">0</span></div>
+            </div>
+            <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
+              <div class="text-slate-300 text-sm">Telemetry Points</div>
+              <div class="text-2xl font-bold mt-1"><span id="kpiPoints">0</span></div>
+            </div>
+            <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
+              <div class="text-slate-300 text-sm">My Jobs</div>
+              <div class="text-2xl font-bold mt-1"><span id="kpiJobs">0</span></div>
+            </div>
+            <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
+              <div class="text-slate-300 text-sm">Signed In</div>
+              <div class="text-2xl font-bold mt-1 truncate" title="Guest"><span id="kpiAccount">Guest</span></div>
+            </div>
+          </section>
+
+          <section class="grid lg:grid-cols-[1.6fr_1fr] gap-4">
+            <div class="space-y-4">
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <h3 class="font-semibold">Live Map</h3>
+                  <div class="text-xs text-slate-400" id="status">Ready.</div>
+                </div>
+                <div id="map" class="h-[440px] rounded-lg overflow-hidden tile-dark"></div>
+              </div>
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <div class="flex items-center justify-between mb-3">
+                  <h3 class="font-semibold">Altitude (k-index)</h3>
+                  <div class="text-xs text-slate-400" id="chartMeta">—</div>
+                </div>
+                <canvas id="altChart" height="160"></canvas>
+              </div>
+            </div>
+
+            <div class="space-y-4">
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <h3 class="font-semibold mb-3">Quick Actions</h3>
+                <div class="space-y-3">
+                  <div class="flex gap-2">
+                    <input id="flightId" class="flex-1 px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 text-sm" placeholder="flight_id" />
+                    <button id="btnCopy" class="px-3 py-2 rounded-lg bg-white/10">Copy</button>
+                  </div>
+                  <div class="grid grid-cols-2 gap-2">
+                    <button id="btnSeed" class="px-3 py-2 rounded-lg grad">Seed & Start</button>
+                    <button id="btnLoad" class="px-3 py-2 rounded-lg bg-white/10">Load & Animate</button>
+                    <button id="btnDemo" class="px-3 py-2 rounded-lg bg-white/10 col-span-2">Start Demo Stream</button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <h3 class="font-semibold mb-3">Recent Flights</h3>
+                <div class="overflow-auto">
+                  <table class="w-full text-sm">
+                    <thead class="text-left text-slate-300">
+                      <tr><th class="py-2">Flight ID</th><th class="py-2">Points</th><th class="py-2">Last Used</th></tr>
+                    </thead>
+                    <tbody id="recentTable" class="text-slate-400"></tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </section>
+        </section>
+
+        <section data-page="jobs" class="space-y-6 hidden">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 class="text-xl font-semibold">Jobs Board</h2>
+              <p class="text-sm text-slate-400">Create, browse, and claim Microsoft Flight Simulator missions.</p>
+            </div>
+            <div class="flex items-center gap-2">
+              <span id="jobsMeta" class="text-xs text-slate-400">—</span>
+              <button id="btnJobsGenerate" class="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm flex items-center gap-2">
+                <i data-lucide="sparkles" class="w-4 h-4"></i>
+                <span>SimuNet auto</span>
+              </button>
+              <button id="btnJobsRefresh" class="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm">Refresh</button>
+            </div>
           </div>
-          <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
-            <div class="text-slate-300 text-sm">Telemetry Points</div>
-            <div class="text-2xl font-bold mt-1"><span id="kpiPoints">0</span></div>
-          </div>
-          <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
-            <div class="text-slate-300 text-sm">Database</div>
-            <div class="text-2xl font-bold mt-1"><span id="kpiDb">offline</span></div>
-          </div>
-          <div class="border border-white/10 rounded-2xl p-4 bg-[#0f1430]">
-            <div class="text-slate-300 text-sm">API</div>
-            <div class="text-2xl font-bold mt-1"><span id="kpiApi">unknown</span></div>
+
+          <div class="grid gap-4 lg:grid-cols-3">
+            <div class="space-y-4">
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <div class="flex items-center justify-between gap-2 mb-3">
+                  <h3 class="text-lg font-semibold text-slate-100">Create Flight Job</h3>
+                  <span class="text-xs uppercase tracking-wide text-indigo-300/80">Microsoft Flight Simulator</span>
+                </div>
+                <form id="formCreateJob" class="space-y-3">
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobTitle">Mission title</label>
+                    <input id="jobTitle" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Mountain relief drop" required />
+                  </div>
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobPayload">Payload</label>
+                    <input id="jobPayload" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Emergency supplies" required />
+                  </div>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobWeight">Weight (lbs)</label>
+                      <input id="jobWeight" type="number" min="0" step="0.1" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="7500" />
+                    </div>
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobDeadline">Deadline</label>
+                      <input id="jobDeadline" type="datetime-local" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" required />
+                    </div>
+                  </div>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobDeparture">Departure</label>
+                      <input id="jobDeparture" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 uppercase" placeholder="KSEA" required maxlength="8" />
+                    </div>
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobArrival">Arrival</label>
+                      <input id="jobArrival" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 uppercase" placeholder="CYVR" required maxlength="8" />
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="jobNotes">Notes</label>
+                    <textarea id="jobNotes" rows="3" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Brief the pilot on weather, cargo handling, or other specifics."></textarea>
+                  </div>
+                  <button type="submit" class="w-full px-3 py-2 rounded-lg grad text-sm font-medium">Publish job</button>
+                </form>
+                <p class="mt-3 text-xs text-slate-400">Jobs are visible to everyone until claimed. Signing in is required to publish or claim.</p>
+              </div>
+            </div>
+
+            <div class="lg:col-span-2 space-y-4">
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-100">Available jobs</h3>
+                    <p class="text-sm text-slate-400">Pick a mission to add it to your hangar.</p>
+                  </div>
+                </div>
+                <div id="jobsAvailable" class="space-y-3"></div>
+                <div id="jobsAvailableEmpty" class="text-sm text-slate-400 text-center py-6 border border-dashed border-white/10 rounded-xl">No jobs available yet. Create one to get started.</div>
+              </div>
+
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-100">My jobs</h3>
+                    <p class="text-sm text-slate-400">Claimed missions stay private to your account.</p>
+                  </div>
+                </div>
+                <div id="jobsMine" class="space-y-3"></div>
+                <div id="jobsMineEmpty" class="text-sm text-slate-400 text-center py-6 border border-dashed border-white/10 rounded-xl">Sign in to track claimed jobs.</div>
+              </div>
+            </div>
           </div>
         </section>
 
-        <section class="grid lg:grid-cols-[1.6fr_1fr] gap-4">
-          <div class="space-y-4">
-            <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
-              <div class="flex items-center justify-between mb-3">
-                <h3 class="font-semibold">Live Map</h3>
-                <div class="text-xs text-slate-400" id="status">Ready.</div>
-              </div>
-              <div id="map" class="h-[440px] rounded-lg overflow-hidden tile-dark"></div>
+        <section data-page="admin" class="space-y-6 hidden">
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <div>
+              <h2 class="text-xl font-semibold">Admin Control Center</h2>
+              <p class="text-sm text-slate-400">Manage SimuNet missions and pilot profiles.</p>
             </div>
-            <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
-              <div class="flex items-center justify-between mb-3">
-                <h3 class="font-semibold">Altitude (k-index)</h3>
-                <div class="text-xs text-slate-400" id="chartMeta">—</div>
-              </div>
-              <canvas id="altChart" height="160"></canvas>
+            <div class="flex items-center gap-2">
+              <span id="adminStatus" class="text-xs text-slate-400">Sign in with an administrator account to continue.</span>
+              <button id="btnAdminRefresh" class="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm hidden">Refresh</button>
             </div>
           </div>
 
-          <div class="space-y-4">
-            <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
-              <h3 class="font-semibold mb-3">Quick Actions</h3>
-              <div class="space-y-3">
-                <div class="flex gap-2">
-                  <input id="flightId" class="flex-1 px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 text-sm" placeholder="flight_id" />
-                  <button id="btnCopy" class="px-3 py-2 rounded-lg bg-white/10">Copy</button>
+          <div id="adminGate" class="border border-dashed border-indigo-400/60 bg-indigo-500/5 rounded-2xl p-6 text-sm text-slate-200">
+            Sign in as a SimuNet administrator to access mission publishing, moderation, and crew management tools.
+          </div>
+
+          <div id="adminContent" class="space-y-6 hidden">
+            <div class="grid lg:grid-cols-2 gap-4">
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4 space-y-4">
+                <div class="flex items-center justify-between gap-2">
+                  <div>
+                    <h3 class="text-lg font-semibold text-slate-100">Publish mission</h3>
+                    <p class="text-xs text-slate-400">Create assignments on behalf of SimuNet Ops.</p>
+                  </div>
                 </div>
-                <div class="grid grid-cols-2 gap-2">
-                  <button id="btnSeed" class="px-3 py-2 rounded-lg grad">Seed & Start</button>
-                  <button id="btnLoad" class="px-3 py-2 rounded-lg bg-white/10">Load & Animate</button>
-                  <button id="btnDemo" class="px-3 py-2 rounded-lg bg-white/10 col-span-2">Start Demo Stream</button>
+                <form id="formAdminJob" class="space-y-3">
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobTitle">Mission title</label>
+                    <input id="adminJobTitle" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Arctic supply run" required />
+                  </div>
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobPayload">Payload</label>
+                    <input id="adminJobPayload" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Medical cargo" required />
+                  </div>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobWeight">Weight (lbs)</label>
+                      <input id="adminJobWeight" type="number" min="0" step="0.1" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="6800" />
+                    </div>
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobDeadline">Deadline</label>
+                      <input id="adminJobDeadline" type="datetime-local" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" required />
+                    </div>
+                  </div>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobDeparture">Departure</label>
+                      <input id="adminJobDeparture" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 uppercase" placeholder="KSEA" required maxlength="8" />
+                    </div>
+                    <div>
+                      <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobArrival">Arrival</label>
+                      <input id="adminJobArrival" type="text" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10 uppercase" placeholder="CYVR" required maxlength="8" />
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobAssign">Assign to (optional)</label>
+                    <input id="adminJobAssign" type="email" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="pilot@example.com" />
+                  </div>
+                  <div>
+                    <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="adminJobNotes">Notes</label>
+                    <textarea id="adminJobNotes" rows="3" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Share weather, coordination, or cargo handling details."></textarea>
+                  </div>
+                  <button type="submit" class="w-full px-3 py-2 rounded-lg grad text-sm font-medium">Publish mission</button>
+                </form>
+                <p class="text-xs text-slate-400">Assignments can optionally be pre-assigned to a pilot email. Leave blank to keep them open.</p>
+              </div>
+
+              <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4 space-y-4">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-100">SimuNet Ops tools</h3>
+                  <p class="text-xs text-slate-400">Automate job creation and keep the board refreshed.</p>
                 </div>
-                <p class="text-xs text-slate-400">Tip: Pass <code>?api=https://your-api.onrender.com</code> in the URL to preset the API.</p>
+                <div class="space-y-3">
+                  <button id="btnAdminGenerate" type="button" class="w-full px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm flex items-center justify-center gap-2">
+                    <i data-lucide="sparkles" class="w-4 h-4"></i>
+                    <span>Generate SimuNet missions</span>
+                  </button>
+                  <p class="text-xs text-slate-400">SimuNet Ops missions come with curated payloads, routes, and deadlines.</p>
+                </div>
               </div>
             </div>
 
             <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
-              <h3 class="font-semibold mb-3">Recent Flights</h3>
+              <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-100">All jobs</h3>
+                  <p class="text-sm text-slate-400">Monitor and remove assignments across the network.</p>
+                </div>
+              </div>
               <div class="overflow-auto">
                 <table class="w-full text-sm">
                   <thead class="text-left text-slate-300">
-                    <tr><th class="py-2">Flight ID</th><th class="py-2">Points</th><th class="py-2">Last Used</th></tr>
+                    <tr>
+                      <th class="py-2">Mission</th>
+                      <th class="py-2">Creator</th>
+                      <th class="py-2">Assigned</th>
+                      <th class="py-2">Deadline</th>
+                      <th class="py-2 text-right">Actions</th>
+                    </tr>
                   </thead>
-                  <tbody id="recentTable" class="text-slate-400"></tbody>
+                  <tbody id="adminJobsBody" class="text-slate-400"></tbody>
                 </table>
               </div>
+              <div id="adminJobsEmpty" class="text-sm text-slate-400 text-center py-6 border border-dashed border-white/10 rounded-xl">No jobs recorded yet.</div>
+            </div>
+
+            <div class="border border-white/10 rounded-2xl bg-[#0f1430] p-4">
+              <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2 mb-3">
+                <div>
+                  <h3 class="text-lg font-semibold text-slate-100">User directory</h3>
+                  <p class="text-sm text-slate-400">Promote admins, reset passwords, or remove inactive accounts.</p>
+                </div>
+              </div>
+              <div class="overflow-auto">
+                <table class="w-full text-sm">
+                  <thead class="text-left text-slate-300">
+                    <tr>
+                      <th class="py-2">Email</th>
+                      <th class="py-2">Role</th>
+                      <th class="py-2">Created</th>
+                      <th class="py-2 text-right">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="adminUsersBody" class="text-slate-400"></tbody>
+                </table>
+              </div>
+              <div id="adminUsersEmpty" class="text-sm text-slate-400 text-center py-6 border border-dashed border-white/10 rounded-xl">No users found.</div>
             </div>
           </div>
         </section>
@@ -122,161 +341,1312 @@
     </div>
   </div>
 
+  <div id="authSheet" class="hidden fixed inset-0 z-[1200] p-4 md:p-8 bg-black/70 backdrop-blur-sm">
+    <div class="relative max-w-md mx-auto mt-12 md:mt-20 bg-[#0f1430] border border-white/10 rounded-2xl p-6 shadow-2xl">
+      <button id="btnAuthClose" class="absolute top-4 right-4 text-slate-400 hover:text-slate-200" type="button" aria-label="Close">
+        <i data-lucide="x" class="w-5 h-5"></i>
+      </button>
+      <div class="space-y-1 text-center mb-4">
+        <h2 class="text-lg font-semibold" id="authTitle">Welcome</h2>
+        <p class="text-sm text-slate-400" id="authSubtitle">Sign in or create an account to personalise your dashboard.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-2 text-sm mb-4">
+        <button class="auth-tab px-3 py-2 rounded-lg bg-white/10 text-white" data-auth-tab="login" type="button">Log in</button>
+        <button class="auth-tab px-3 py-2 rounded-lg bg-white/5 text-slate-300 hover:bg-white/10" data-auth-tab="register" type="button">Create account</button>
+      </div>
+      <div id="authAccountSummary" class="hidden text-left mb-4 border border-white/10 rounded-xl p-4 bg-[#0b1020]/60">
+        <div class="font-medium text-slate-100" id="summaryEmail"></div>
+        <div class="text-xs text-slate-400" id="summaryCreated"></div>
+      </div>
+      <div id="authError" class="hidden mb-3 text-sm text-rose-300 bg-rose-500/10 border border-rose-400/40 rounded-lg px-3 py-2"></div>
+      <div id="authSuccess" class="hidden mb-3 text-sm text-emerald-300 bg-emerald-500/10 border border-emerald-400/40 rounded-lg px-3 py-2"></div>
+      <form id="formLogin" class="space-y-3">
+        <div class="text-left">
+          <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="loginEmail">Email</label>
+          <input id="loginEmail" type="email" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="you@example.com" autocomplete="email" required />
+        </div>
+        <div class="text-left">
+          <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="loginPassword">Password</label>
+          <input id="loginPassword" type="password" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="••••••••" autocomplete="current-password" minlength="8" required />
+        </div>
+        <button type="submit" class="w-full px-3 py-2 rounded-lg grad text-sm font-medium">Log in</button>
+      </form>
+      <form id="formRegister" class="space-y-3 hidden">
+        <div class="text-left">
+          <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="registerEmail">Email</label>
+          <input id="registerEmail" type="email" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="you@example.com" autocomplete="email" required />
+        </div>
+        <div class="text-left">
+          <label class="block text-xs uppercase tracking-wide text-slate-400 mb-1" for="registerPassword">Password</label>
+          <input id="registerPassword" type="password" class="w-full px-3 py-2 rounded-lg bg-[#0f1538] border border-white/10" placeholder="Min. 8 characters" autocomplete="new-password" minlength="8" required />
+        </div>
+        <p class="text-xs text-slate-400">Passwords are stored securely using PBKDF2 hashing.</p>
+        <button type="submit" class="w-full px-3 py-2 rounded-lg grad text-sm font-medium">Create account</button>
+      </form>
+      <button id="btnLogout" class="hidden w-full mt-4 px-3 py-2 rounded-lg bg-white/10 hover:bg-white/15 text-sm" type="button">Sign out</button>
+    </div>
+  </div>
+
   <script>
     lucide.createIcons();
-    document.getElementById('themeToggle').addEventListener('click', ()=> document.documentElement.classList.toggle('dark'));
+    document.getElementById('themeToggle').addEventListener('click', () => document.documentElement.classList.toggle('dark'));
 
     const ls = window.localStorage;
-    const qsApi = new URLSearchParams(location.search).get('api');
-    const apiInput = document.getElementById('api');
-    const detected = (location.origin.includes('localhost') || location.protocol==='file:') ? 'http://localhost:8000' : location.origin;
-    apiInput.value = qsApi || ls.getItem('simunet_api') || detected;
-    apiInput.addEventListener('change', ()=> ls.setItem('simunet_api', apiInput.value.trim()));
+    const USER_KEY = 'simunet_user';
 
-    const map = L.map('map', { zoomControl: true }).setView([39.5,-98.35], 4);
+    const API_BASE = (() => {
+      const param = new URLSearchParams(location.search).get('api');
+      if (param) {
+        return param.replace(/\/$/, '');
+      }
+      const origin = location.origin;
+      if (origin && origin !== 'null' && !origin.startsWith('file:')) {
+        return origin.replace(/\/$/, '');
+      }
+      return 'http://localhost:8000';
+    })();
+
+    const map = L.map('map', { zoomControl: true }).setView([39.5, -98.35], 4);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap' }).addTo(map);
-    const pathLine = L.polyline([], { weight: 3, opacity: .95 }).addTo(map);
-    const marker = L.circleMarker([0,0], { radius: 6, weight: 2 }).addTo(map);
+    const pathLine = L.polyline([], { weight: 3, opacity: 0.95 }).addTo(map);
+    const marker = L.circleMarker([0, 0], { radius: 6, weight: 2 }).addTo(map);
 
     const statusEl = document.getElementById('status');
     const kpiFlights = document.getElementById('kpiFlights');
-    const kpiPoints  = document.getElementById('kpiPoints');
-    const kpiDb      = document.getElementById('kpiDb');
-    const kpiApi     = document.getElementById('kpiApi');
-    const dbStatus   = document.getElementById('dbStatus');
-    const apiStatus  = document.getElementById('apiStatus');
+    const kpiPoints = document.getElementById('kpiPoints');
+    const kpiJobs = document.getElementById('kpiJobs');
+    const kpiAccount = document.getElementById('kpiAccount');
+    const dbStatus = document.getElementById('dbStatus');
+    const apiStatus = document.getElementById('apiStatus');
     const flightIdEl = document.getElementById('flightId');
     const recentTable = document.getElementById('recentTable');
     const chartMeta = document.getElementById('chartMeta');
+    const jobsAvailable = document.getElementById('jobsAvailable');
+    const jobsAvailableEmpty = document.getElementById('jobsAvailableEmpty');
+    const jobsMine = document.getElementById('jobsMine');
+    const jobsMineEmpty = document.getElementById('jobsMineEmpty');
+    const jobsMeta = document.getElementById('jobsMeta');
+    const btnJobsGenerate = document.getElementById('btnJobsGenerate');
+    const btnJobsRefresh = document.getElementById('btnJobsRefresh');
+    const formCreateJob = document.getElementById('formCreateJob');
+    const jobTitle = document.getElementById('jobTitle');
+    const jobPayload = document.getElementById('jobPayload');
+    const jobWeight = document.getElementById('jobWeight');
+    const jobDeparture = document.getElementById('jobDeparture');
+    const jobArrival = document.getElementById('jobArrival');
+    const jobDeadline = document.getElementById('jobDeadline');
+    const jobNotes = document.getElementById('jobNotes');
+    const navAdmin = document.getElementById('navAdmin');
+    const adminStatus = document.getElementById('adminStatus');
+    const adminGate = document.getElementById('adminGate');
+    const adminContent = document.getElementById('adminContent');
+    const btnAdminRefresh = document.getElementById('btnAdminRefresh');
+    const btnAdminGenerate = document.getElementById('btnAdminGenerate');
+    const formAdminJob = document.getElementById('formAdminJob');
+    const adminJobTitle = document.getElementById('adminJobTitle');
+    const adminJobPayload = document.getElementById('adminJobPayload');
+    const adminJobWeight = document.getElementById('adminJobWeight');
+    const adminJobDeparture = document.getElementById('adminJobDeparture');
+    const adminJobArrival = document.getElementById('adminJobArrival');
+    const adminJobDeadline = document.getElementById('adminJobDeadline');
+    const adminJobNotes = document.getElementById('adminJobNotes');
+    const adminJobAssign = document.getElementById('adminJobAssign');
+    const adminJobsBody = document.getElementById('adminJobsBody');
+    const adminJobsEmpty = document.getElementById('adminJobsEmpty');
+    const adminUsersBody = document.getElementById('adminUsersBody');
+    const adminUsersEmpty = document.getElementById('adminUsersEmpty');
+    const pages = document.querySelectorAll('[data-page]');
+    const navLinks = document.querySelectorAll('[data-nav]');
+    const accountButton = document.getElementById('btnAccount');
+    const accountAvatar = document.getElementById('accountAvatar');
+    const accountLabel = document.getElementById('accountLabel');
+    const authSheet = document.getElementById('authSheet');
+    const btnAuthClose = document.getElementById('btnAuthClose');
+    const authTabs = document.querySelectorAll('.auth-tab');
+    const formLogin = document.getElementById('formLogin');
+    const formRegister = document.getElementById('formRegister');
+    const loginEmail = document.getElementById('loginEmail');
+    const loginPassword = document.getElementById('loginPassword');
+    const registerEmail = document.getElementById('registerEmail');
+    const registerPassword = document.getElementById('registerPassword');
+    const authError = document.getElementById('authError');
+    const authSuccess = document.getElementById('authSuccess');
+    const authAccountSummary = document.getElementById('authAccountSummary');
+    const summaryEmail = document.getElementById('summaryEmail');
+    const summaryCreated = document.getElementById('summaryCreated');
+    const btnLogout = document.getElementById('btnLogout');
+    const authTitle = document.getElementById('authTitle');
+    const authSubtitle = document.getElementById('authSubtitle');
 
-    function setBadge(el, text, cls){
+    let jobsLoaded = false;
+    let adminLoaded = false;
+
+    function setJobDeadlineDefault(input) {
+      if (!input) {
+        return;
+      }
+      const baseline = new Date(Date.now() + 2 * 60 * 60 * 1000);
+      const tzOffset = baseline.getTimezoneOffset() * 60000;
+      const local = new Date(baseline.getTime() - tzOffset);
+      input.value = local.toISOString().slice(0, 16);
+    }
+
+    setJobDeadlineDefault(jobDeadline);
+    setJobDeadlineDefault(adminJobDeadline);
+
+    [jobDeparture, jobArrival, adminJobDeparture, adminJobArrival].forEach((input) => {
+      if (!input) {
+        return;
+      }
+      input.addEventListener('blur', () => {
+        input.value = input.value.trim().toUpperCase();
+      });
+    });
+    let currentUser = null;
+
+    function setBadge(el, text, cls) {
       el.textContent = text;
       el.className = 'text-xs px-2 py-1 rounded-full border ' + (cls || 'border-white/10 text-slate-300');
     }
-    function fmtDate(n){ const d = new Date(n); return d.toLocaleString(); }
 
-    function saveRecent(fid, count){
+    function fmtDate(value) {
+      if (!value) return '—';
+      const d = new Date(value);
+      if (Number.isNaN(d.getTime())) return value;
+      return d.toLocaleString();
+    }
+
+    function escapeHtml(value) {
+      return String(value).replace(/[&<>"']/g, (char) => {
+        switch (char) {
+          case '&': return '&amp;';
+          case '<': return '&lt;';
+          case '>': return '&gt;';
+          case '"': return '&quot;';
+          case "'": return '&#39;';
+          default: return char;
+        }
+      });
+    }
+
+    function saveRecent(fid, count) {
       const rec = JSON.parse(ls.getItem('simunet_recent') || '[]');
       const now = Date.now();
-      const idx = rec.findIndex(r => r.flight_id === fid);
-      if(idx>=0){ rec[idx] = { flight_id: fid, points: count, used_at: now }; }
-      else { rec.unshift({ flight_id: fid, points: count, used_at: now }); }
-      ls.setItem('simunet_recent', JSON.stringify(rec.slice(0,25)));
+      const idx = rec.findIndex((r) => r.flight_id === fid);
+      if (idx >= 0) {
+        rec[idx] = { flight_id: fid, points: count, used_at: now };
+      } else {
+        rec.unshift({ flight_id: fid, points: count, used_at: now });
+      }
+      ls.setItem('simunet_recent', JSON.stringify(rec.slice(0, 25)));
       renderRecent();
     }
-    function renderRecent(){
+
+    function renderRecent() {
       const rec = JSON.parse(ls.getItem('simunet_recent') || '[]');
       recentTable.innerHTML = '';
-      rec.forEach(r => {
+      rec.forEach((r) => {
         const tr = document.createElement('tr');
-        tr.innerHTML = '<td class="py-2"><button class="underline hover:text-slate-200" data-fid="'+r.flight_id+'">'+r.flight_id+'</button></td>' +
-                       '<td class="py-2 text-slate-300">'+(r.points||0)+'</td>' +
-                       '<td class="py-2">'+fmtDate(r.used_at)+'</td>';
-        tr.querySelector('button').onclick = (e)=> { flightIdEl.value = e.target.dataset.fid; };
+        tr.innerHTML = '<td class="py-2"><button class="underline hover:text-slate-200" data-fid="' + r.flight_id + '">' + r.flight_id + '</button></td>' +
+          '<td class="py-2 text-slate-300">' + (r.points || 0) + '</td>' +
+          '<td class="py-2">' + fmtDate(r.used_at) + '</td>';
+        tr.querySelector('button').onclick = (e) => { flightIdEl.value = e.target.dataset.fid; };
         recentTable.appendChild(tr);
       });
       kpiFlights.textContent = rec.length;
     }
+
     renderRecent();
 
-    async function apiFetch(path, opts){
-      const api = apiInput.value.trim().replace(/\/$/, '');
-      const r = await fetch(api + path, opts);
-      if (!r.ok) throw new Error((await r.text()) || ('HTTP ' + r.status));
-      return r.json();
+    async function apiFetch(path, opts = {}) {
+      const response = await fetch(API_BASE + path, opts);
+      const text = await response.text();
+      let data = {};
+      if (text) {
+        try { data = JSON.parse(text); } catch (err) { data = text; }
+      }
+      if (!response.ok) {
+        if (data && typeof data === 'object' && data.detail) {
+          throw new Error(data.detail);
+        }
+        throw new Error(typeof data === 'string' ? data : ('HTTP ' + response.status));
+      }
+      if (typeof data === 'string' || data === null) {
+        return { ok: true, detail: data };
+      }
+      return data;
     }
 
-    document.getElementById('btnPing').addEventListener('click', async ()=>{
-      setBadge(apiStatus, 'checking...', 'border-white/10 text-slate-400');
-      try{
-        const s = await apiFetch('/status');
-        kpiDb.textContent = s.db ? 'online' : 'offline';
-        setBadge(dbStatus, s.db ? 'db: online' : 'db: offline', s.db ? 'border-emerald-400/40 text-emerald-300' : 'border-amber-400/40 text-amber-300');
-        setBadge(apiStatus, 'reachable', 'border-emerald-400/40 text-emerald-300');
-        kpiApi.textContent = 'reachable';
-        statusEl.textContent = 'OK';
-      }catch(e){
-        kpiDb.textContent = 'offline';
-        setBadge(dbStatus, 'db: error', 'border-rose-400/40 text-rose-300');
-        setBadge(apiStatus, 'unreachable', 'border-rose-400/40 text-rose-300');
-        kpiApi.textContent = 'unreachable';
-        statusEl.textContent = 'API not reachable.';
+    function setCurrentUser(user) {
+      currentUser = user || null;
+      if (currentUser) {
+        ls.setItem(USER_KEY, JSON.stringify(currentUser));
+      } else {
+      ls.removeItem(USER_KEY);
+    }
+    updateAccountUI();
+    updateAdminUI();
+    if (kpiAccount) {
+      const label = currentUser && currentUser.email ? currentUser.email : 'Guest';
+        kpiAccount.textContent = label;
+        if (kpiAccount.parentElement) {
+          kpiAccount.parentElement.setAttribute('title', label);
+        }
+      }
+      if (!currentUser && kpiJobs) {
+        kpiJobs.textContent = '0';
+      }
+      jobsLoaded = false;
+      loadJobs(false);
+    }
+
+    function loadStoredUser() {
+      let stored = null;
+      try {
+        stored = JSON.parse(ls.getItem(USER_KEY) || 'null');
+      } catch (err) {
+        console.warn('Unable to parse stored user', err);
+      }
+      if (stored && stored.email) {
+        setCurrentUser(stored);
+        return;
+      }
+      setCurrentUser(null);
+    }
+
+    function updateAccountUI() {
+      if (currentUser && currentUser.email) {
+        const initial = currentUser.email.charAt(0).toUpperCase();
+        accountAvatar.textContent = initial;
+        accountLabel.textContent = currentUser.email;
+        accountLabel.classList.remove('text-slate-300');
+        accountLabel.classList.add('text-slate-100');
+      } else {
+        accountAvatar.textContent = '?';
+        accountLabel.textContent = 'Sign in';
+        accountLabel.classList.add('text-slate-300');
+        accountLabel.classList.remove('text-slate-100');
+      }
+    }
+
+    function updateAdminUI() {
+      const isAdmin = Boolean(currentUser && currentUser.is_admin);
+      if (navAdmin) {
+        navAdmin.classList.toggle('hidden', !isAdmin);
+      }
+      if (btnAdminRefresh) {
+        btnAdminRefresh.classList.toggle('hidden', !isAdmin);
+      }
+      if (adminGate) {
+        adminGate.classList.toggle('hidden', isAdmin);
+      }
+      if (adminContent) {
+        adminContent.classList.toggle('hidden', !isAdmin);
+      }
+      if (!isAdmin) {
+        adminLoaded = false;
+        if (adminStatus) {
+          adminStatus.textContent = 'Sign in with an administrator account to continue.';
+        }
+      } else if (adminStatus && !adminLoaded) {
+        adminStatus.textContent = 'Admin tools ready. Refresh to load data.';
+      }
+    }
+
+    function toggleAuthSheet(show, defaultTab = 'login') {
+      authSheet.classList.toggle('hidden', !show);
+      if (show) {
+        document.body.classList.add('overflow-hidden');
+        switchAuthTab(defaultTab);
+        if (!currentUser) {
+          authTitle.textContent = defaultTab === 'register' ? 'Create your SimuNet account' : 'Welcome back';
+          authSubtitle.textContent = 'Access demo tools, seed jobs, and monitor telemetry.';
+        } else {
+          authTitle.textContent = 'Account';
+          authSubtitle.textContent = 'You are signed in with ' + currentUser.email + '.';
+        }
+      } else {
+        document.body.classList.remove('overflow-hidden');
+      }
+    }
+
+    function switchAuthTab(tab) {
+      authTabs.forEach((btn) => {
+        const active = btn.dataset.authTab === tab;
+        btn.classList.toggle('bg-white/10', active);
+        btn.classList.toggle('text-white', active);
+        btn.classList.toggle('bg-white/5', !active);
+        btn.classList.toggle('text-slate-300', !active);
+      });
+
+      const showForms = !currentUser;
+      formLogin.classList.toggle('hidden', tab !== 'login' || !showForms);
+      formRegister.classList.toggle('hidden', tab !== 'register' || !showForms);
+      authAccountSummary.classList.toggle('hidden', !!showForms || !currentUser);
+      btnLogout.classList.toggle('hidden', !currentUser);
+
+      if (currentUser) {
+        summaryEmail.textContent = currentUser.email;
+        summaryCreated.textContent = currentUser.created_at ? 'Joined ' + fmtDate(currentUser.created_at) : '';
+      }
+
+      authError.classList.add('hidden');
+      authSuccess.classList.add('hidden');
+    }
+
+    accountButton.addEventListener('click', () => {
+      toggleAuthSheet(true, currentUser ? 'login' : 'login');
+    });
+
+    btnAuthClose.addEventListener('click', () => toggleAuthSheet(false));
+
+    authTabs.forEach((btn) => {
+      btn.addEventListener('click', () => switchAuthTab(btn.dataset.authTab || 'login'));
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !authSheet.classList.contains('hidden')) {
+        toggleAuthSheet(false);
       }
     });
 
-    document.getElementById('btnCopy').addEventListener('click', async ()=>{
-      const fid = flightIdEl.value.trim(); if(!fid) return;
-      try{ await navigator.clipboard.writeText(fid);}catch{}
+    btnLogout.addEventListener('click', () => {
+      setCurrentUser(null);
+      toggleAuthSheet(false);
+      statusEl.textContent = 'Signed out.';
     });
 
-    document.getElementById('btnSeed').addEventListener('click', async ()=>{
+    async function handleAuthSubmit(type, email, password) {
+      if (!email || !password) {
+        authError.textContent = 'Email and password required.';
+        authError.classList.remove('hidden');
+        return;
+      }
+      authError.classList.add('hidden');
+      authSuccess.classList.add('hidden');
+      const path = type === 'register' ? '/auth/register' : '/auth/login';
+      try {
+        const res = await apiFetch(path, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+        if (res && res.user) {
+          setCurrentUser(res.user);
+          authSuccess.textContent = type === 'register' ? 'Account created! You are now signed in.' : 'Signed in successfully.';
+          authSuccess.classList.remove('hidden');
+          summaryEmail.textContent = res.user.email;
+          summaryCreated.textContent = res.user.created_at ? 'Joined ' + fmtDate(res.user.created_at) : '';
+          switchAuthTab('login');
+          toggleAuthSheet(false);
+          statusEl.textContent = `Signed in as ${res.user.email}.`;
+        }
+      } catch (err) {
+        authError.textContent = (err && err.message) ? err.message : 'Unable to complete request.';
+        authError.classList.remove('hidden');
+      }
+    }
+
+    formLogin.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      handleAuthSubmit('login', loginEmail.value.trim().toLowerCase(), loginPassword.value);
+    });
+
+    formRegister.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      handleAuthSubmit('register', registerEmail.value.trim().toLowerCase(), registerPassword.value);
+    });
+
+    async function checkStatus(updateMessage = true) {
+      setBadge(apiStatus, 'api: checking...', 'border-white/10 text-slate-400');
+      try {
+        const s = await apiFetch('/status');
+        setBadge(dbStatus, s.db ? 'db: online' : 'db: offline', s.db ? 'border-emerald-400/40 text-emerald-300' : 'border-amber-400/40 text-amber-300');
+        setBadge(apiStatus, 'api: reachable', 'border-emerald-400/40 text-emerald-300');
+        if (updateMessage) {
+          statusEl.textContent = 'API ready.';
+        }
+      } catch (e) {
+        console.error(e);
+        setBadge(dbStatus, 'db: error', 'border-rose-400/40 text-rose-300');
+        setBadge(apiStatus, 'api: unreachable', 'border-rose-400/40 text-rose-300');
+        if (updateMessage) {
+          statusEl.textContent = 'API not reachable.';
+        }
+      }
+    }
+
+    document.getElementById('btnCopy').addEventListener('click', async () => {
+      const fid = flightIdEl.value.trim();
+      if (!fid) return;
+      try {
+        await navigator.clipboard.writeText(fid);
+      } catch (err) {
+        console.warn('clipboard copy failed', err);
+      }
+    });
+
+    async function loadJobs(updateStatus = true) {
+      if (!jobsAvailable || !jobsAvailableEmpty || !jobsMine || !jobsMineEmpty) {
+        return;
+      }
+
+      const signedIn = Boolean(currentUser && currentUser.email);
+
+      if (jobsMeta) {
+        jobsMeta.textContent = 'Loading jobs…';
+      }
+
+      try {
+        const email = signedIn ? currentUser.email.toLowerCase() : null;
+        const path = email ? `/jobs?email=${encodeURIComponent(email)}` : '/jobs';
+        const res = await apiFetch(path);
+        const available = Array.isArray(res.available) ? res.available : Array.isArray(res.jobs) ? res.jobs : [];
+        const mine = signedIn ? (Array.isArray(res.mine) ? res.mine : []) : [];
+        renderJobs(available, mine);
+        jobsLoaded = true;
+        if (updateStatus) {
+          const parts = [`${available.length} available`];
+          if (signedIn) {
+            parts.push(`${mine.length} mine`);
+          }
+          statusEl.textContent = `Jobs refreshed (${parts.join(' • ')}).`;
+        }
+      } catch (err) {
+        console.error(err);
+        jobsLoaded = false;
+        if (jobsMeta) {
+          jobsMeta.textContent = 'Jobs unavailable';
+        }
+        if (jobsAvailable) {
+          jobsAvailable.innerHTML = '';
+        }
+        if (jobsMine) {
+          jobsMine.innerHTML = '';
+        }
+        if (jobsAvailableEmpty) {
+          jobsAvailableEmpty.textContent = 'Jobs unavailable.';
+          jobsAvailableEmpty.classList.remove('hidden');
+        }
+        if (jobsMineEmpty) {
+          jobsMineEmpty.textContent = signedIn ? 'Jobs unavailable.' : 'Sign in to track claimed jobs.';
+          jobsMineEmpty.classList.remove('hidden');
+        }
+        if (kpiJobs) {
+          kpiJobs.textContent = signedIn ? '0' : '0';
+        }
+        if (updateStatus) {
+          statusEl.textContent = err instanceof Error ? err.message : 'Unable to load jobs.';
+        }
+      }
+    }
+
+    async function loadAdminOverview(force = false) {
+      if (!currentUser || !currentUser.email || !currentUser.is_admin) {
+        return;
+      }
+      if (adminLoaded && !force) {
+        return;
+      }
+
+      if (adminStatus) {
+        adminStatus.textContent = 'Loading admin data…';
+      }
+
+      const actor = encodeURIComponent(currentUser.email.toLowerCase());
+      try {
+        const [jobsRes, usersRes] = await Promise.all([
+          apiFetch(`/admin/jobs?actor=${actor}`),
+          apiFetch(`/admin/users?actor=${actor}`),
+        ]);
+        const jobsList = jobsRes && Array.isArray(jobsRes.jobs) ? jobsRes.jobs : [];
+        const usersList = usersRes && Array.isArray(usersRes.users) ? usersRes.users : [];
+        renderAdminJobs(jobsList);
+        renderAdminUsers(usersList);
+        adminLoaded = true;
+        if (adminStatus) {
+          adminStatus.textContent = 'Admin data updated ' + new Date().toLocaleTimeString();
+        }
+      } catch (err) {
+        console.error(err);
+        adminLoaded = false;
+        if (adminStatus) {
+          adminStatus.textContent = err instanceof Error ? err.message : 'Unable to load admin data.';
+        }
+      }
+    }
+
+    function renderJobs(availableJobs, myJobs) {
+      const signedIn = Boolean(currentUser && currentUser.email);
+      renderJobCollection(jobsAvailable, jobsAvailableEmpty, availableJobs, { allowClaim: true, signedIn, mineList: false });
+      renderJobCollection(jobsMine, jobsMineEmpty, signedIn ? myJobs : [], { allowClaim: false, signedIn, mineList: true });
+
+      if (jobsMeta) {
+        const stamp = new Date().toLocaleTimeString();
+        const parts = [`${availableJobs.length} available`];
+        if (signedIn) {
+          parts.push(`${myJobs.length} mine`);
+        }
+        jobsMeta.textContent = `${parts.join(' • ')} • updated ${stamp}`;
+      }
+
+      if (kpiJobs) {
+        kpiJobs.textContent = signedIn ? String(myJobs.length) : '0';
+      }
+    }
+
+    function renderJobCollection(container, emptyEl, jobs, { allowClaim, signedIn, mineList }) {
+      if (!container || !emptyEl) {
+        return;
+      }
+
+      container.innerHTML = '';
+      const hasJobs = Array.isArray(jobs) && jobs.length > 0;
+
+      if (!hasJobs) {
+        if (mineList) {
+          emptyEl.textContent = signedIn ? 'You have not claimed any jobs yet.' : 'Sign in to track claimed jobs.';
+        } else {
+          emptyEl.textContent = 'No jobs available yet. Create one or ask SimuNet to auto-generate missions.';
+        }
+        emptyEl.classList.remove('hidden');
+        return;
+      }
+
+      emptyEl.classList.add('hidden');
+      jobs.forEach((job) => {
+        container.appendChild(buildJobCard(job, { allowClaim, signedIn }));
+      });
+    }
+
+    function renderAdminJobs(jobs) {
+      if (!adminJobsBody || !adminJobsEmpty) {
+        return;
+      }
+      adminJobsBody.innerHTML = '';
+      const list = Array.isArray(jobs) ? jobs : [];
+      if (!list.length) {
+        adminJobsEmpty.classList.remove('hidden');
+        return;
+      }
+      adminJobsEmpty.classList.add('hidden');
+      list.forEach((job) => {
+        const jobId = job && job.job_id ? String(job.job_id) : '';
+        const row = document.createElement('tr');
+        row.className = 'border-b border-white/5 last:border-0';
+        const title = escapeHtml(job && job.title ? job.title : (jobId || 'Mission'));
+        const creator = escapeHtml(job && job.created_by ? job.created_by : 'SimuNet Ops');
+        const assigned = job && job.assigned_to ? escapeHtml(job.assigned_to) : '—';
+        const deadlineText = job && job.deadline ? escapeHtml(fmtDate(job.deadline)) : '—';
+        row.innerHTML = `
+          <td class="py-2 font-medium text-slate-100">${title}</td>
+          <td class="py-2 text-slate-400">${creator}</td>
+          <td class="py-2 text-slate-400">${assigned}</td>
+          <td class="py-2 text-slate-400">${deadlineText}</td>
+          <td class="py-2 text-right">
+            <button class="px-2 py-1 rounded bg-red-500/20 hover:bg-red-500/30 text-xs text-red-200" type="button" data-action="delete">Delete</button>
+          </td>`;
+        const deleteBtn = row.querySelector('[data-action="delete"]');
+        if (deleteBtn) {
+          deleteBtn.addEventListener('click', () => handleAdminDeleteJob(jobId, job && job.title ? job.title : jobId));
+        }
+        adminJobsBody.appendChild(row);
+      });
+    }
+
+    function renderAdminUsers(users) {
+      if (!adminUsersBody || !adminUsersEmpty) {
+        return;
+      }
+      adminUsersBody.innerHTML = '';
+      const list = Array.isArray(users) ? users : [];
+      if (!list.length) {
+        adminUsersEmpty.classList.remove('hidden');
+        return;
+      }
+      adminUsersEmpty.classList.add('hidden');
+      list.forEach((user) => {
+        const email = user && user.email ? String(user.email) : '';
+        const isAdmin = Boolean(user && user.is_admin);
+        const createdText = user && user.created_at ? fmtDate(user.created_at) : '—';
+        const row = document.createElement('tr');
+        row.className = 'border-b border-white/5 last:border-0';
+        row.innerHTML = `
+          <td class="py-2 font-medium text-slate-100">${escapeHtml(email || '—')}</td>
+          <td class="py-2 text-slate-300">${isAdmin ? 'Admin' : 'User'}</td>
+          <td class="py-2 text-slate-400">${escapeHtml(createdText)}</td>
+          <td class="py-2">
+            <div class="flex flex-wrap justify-end gap-2">
+              <button class="px-2 py-1 rounded bg-white/10 hover:bg-white/15 text-xs" type="button" data-action="toggle">${isAdmin ? 'Revoke admin' : 'Make admin'}</button>
+              <button class="px-2 py-1 rounded bg-white/10 hover:bg-white/15 text-xs" type="button" data-action="reset">Reset password</button>
+              <button class="px-2 py-1 rounded bg-red-500/20 hover:bg-red-500/30 text-xs text-red-200" type="button" data-action="delete">Delete</button>
+            </div>
+          </td>`;
+        const toggleBtn = row.querySelector('[data-action="toggle"]');
+        if (toggleBtn) {
+          toggleBtn.addEventListener('click', () => handleAdminToggleUser(email, !isAdmin));
+        }
+        const resetBtn = row.querySelector('[data-action="reset"]');
+        if (resetBtn) {
+          resetBtn.addEventListener('click', () => handleAdminResetPassword(email));
+        }
+        const deleteBtn = row.querySelector('[data-action="delete"]');
+        if (deleteBtn) {
+          deleteBtn.addEventListener('click', () => handleAdminDeleteUser(email));
+        }
+        adminUsersBody.appendChild(row);
+      });
+    }
+
+    function buildJobCard(job, { allowClaim, signedIn }) {
+      const card = document.createElement('div');
+      card.className = 'border border-white/10 rounded-xl p-4 bg-[#0b1020]/60';
+
+      const title = escapeHtml(job.title || job.job_id || 'Flight job');
+      const platform = escapeHtml(job.platform || 'Microsoft Flight Simulator');
+      const payloadLabel = escapeHtml(job.payload || '—');
+      const departure = escapeHtml((job.departure_airport || '—').toString());
+      const arrival = escapeHtml((job.arrival_airport || '—').toString());
+      const statusLabel = escapeHtml(job.status || (job.assigned_to ? 'claimed' : 'open'));
+      const createdByRaw = job.created_by ? job.created_by.toString() : '';
+      const createdByLabel = createdByRaw && createdByRaw.toLowerCase() === 'ops@simunet.local' ? 'SimuNet Ops' : (createdByRaw || 'SimuNet Ops');
+      const createdBy = escapeHtml(createdByLabel);
+      const assignedTo = job.assigned_to ? escapeHtml(job.assigned_to) : '';
+      const deadlineText = job.deadline ? fmtDate(job.deadline) : 'No deadline';
+      const createdAtText = job.created_at ? fmtDate(job.created_at) : '—';
+      const notes = job.notes ? escapeHtml(job.notes).replace(/\n/g, '<br>') : '';
+      let weightText = '—';
+      if (typeof job.weight_lbs === 'number') {
+        weightText = `${Number(job.weight_lbs).toLocaleString(undefined, { maximumFractionDigits: 1 })} lbs`;
+      }
+
+      card.innerHTML = `
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <div class="font-semibold text-slate-100">${title}</div>
+            <div class="text-xs uppercase tracking-wide text-indigo-300/70 mt-1">${platform}</div>
+          </div>
+          <div class="text-xs uppercase tracking-wide text-slate-400">${statusLabel}</div>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-slate-300 mt-4">
+          <div>
+            <div class="text-xs text-slate-400 uppercase tracking-wide">Route</div>
+            <div class="font-medium text-slate-100">${departure} → ${arrival}</div>
+          </div>
+          <div>
+            <div class="text-xs text-slate-400 uppercase tracking-wide">Deadline</div>
+            <div class="font-medium text-slate-100">${deadlineText}</div>
+          </div>
+          <div>
+            <div class="text-xs text-slate-400 uppercase tracking-wide">Payload</div>
+            <div class="font-medium text-slate-100">${payloadLabel}</div>
+          </div>
+          <div>
+            <div class="text-xs text-slate-400 uppercase tracking-wide">Weight</div>
+            <div class="font-medium text-slate-100">${weightText}</div>
+          </div>
+          <div>
+            <div class="text-xs text-slate-400 uppercase tracking-wide">Created</div>
+            <div class="font-medium text-slate-100">${escapeHtml(createdAtText)}</div>
+          </div>
+        </div>
+      `;
+
+      if (notes) {
+        const notesEl = document.createElement('p');
+        notesEl.className = 'mt-3 text-xs text-slate-400 leading-relaxed';
+        notesEl.innerHTML = `<span class="uppercase tracking-wide text-slate-500 mr-2">Notes</span>${notes}`;
+        card.appendChild(notesEl);
+      }
+
+      const footer = document.createElement('div');
+      footer.className = 'mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 flex-wrap text-xs text-slate-400';
+      const createdEl = document.createElement('div');
+      createdEl.innerHTML = `Created by <span class="text-slate-200">${createdBy}</span>`;
+      footer.appendChild(createdEl);
+
+      if (assignedTo) {
+        const assignedEl = document.createElement('div');
+        assignedEl.innerHTML = `Assigned to <span class="text-slate-200">${assignedTo}</span>`;
+        footer.appendChild(assignedEl);
+      }
+
+      if (allowClaim) {
+        const claimBtn = document.createElement('button');
+        claimBtn.type = 'button';
+        if (signedIn) {
+          claimBtn.className = 'sm:ml-auto px-3 py-2 rounded-lg grad text-sm font-medium';
+          claimBtn.textContent = 'Claim job';
+          claimBtn.addEventListener('click', () => handleClaim(job.job_id));
+        } else {
+          claimBtn.className = 'sm:ml-auto px-3 py-2 rounded-lg bg-white/10 text-sm text-slate-300 cursor-not-allowed';
+          claimBtn.textContent = 'Sign in to claim';
+          claimBtn.disabled = true;
+        }
+        footer.appendChild(claimBtn);
+      }
+
+      card.appendChild(footer);
+      return card;
+    }
+
+    async function handleClaim(jobId) {
+      if (!jobId) {
+        return;
+      }
+      if (!currentUser || !currentUser.email) {
+        statusEl.textContent = 'Sign in to claim jobs.';
+        toggleAuthSheet(true, 'login');
+        return;
+      }
+      statusEl.textContent = 'Claiming job...';
+      try {
+        await apiFetch(`/jobs/${encodeURIComponent(jobId)}/claim`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: currentUser.email.toLowerCase() }),
+        });
+        await loadJobs(true);
+        statusEl.textContent = 'Job claimed.';
+      } catch (err) {
+        console.error(err);
+        statusEl.textContent = err instanceof Error ? err.message : 'Unable to claim job.';
+      }
+    }
+
+    async function handleAdminDeleteJob(jobId, label) {
+      if (!jobId || !currentUser || !currentUser.email || !currentUser.is_admin) {
+        return;
+      }
+      const promptLabel = label ? `Delete job "${label}"?` : 'Delete this job?';
+      if (!window.confirm(promptLabel)) {
+        return;
+      }
+      const actor = encodeURIComponent(currentUser.email.toLowerCase());
+      try {
+        await apiFetch(`/admin/jobs/${encodeURIComponent(jobId)}?actor=${actor}`, { method: 'DELETE' });
+        if (adminStatus) {
+          adminStatus.textContent = 'Job removed.';
+        }
+        await Promise.all([loadAdminOverview(true), loadJobs(true)]);
+      } catch (err) {
+        console.error(err);
+        if (adminStatus) {
+          adminStatus.textContent = err instanceof Error ? err.message : 'Unable to remove job.';
+        }
+      }
+    }
+
+    async function handleAdminToggleUser(email, makeAdmin) {
+      if (!email || !currentUser || !currentUser.email || !currentUser.is_admin) {
+        return;
+      }
+      const actor = encodeURIComponent(currentUser.email.toLowerCase());
+      try {
+        const response = await apiFetch(`/admin/users/${encodeURIComponent(email)}?actor=${actor}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ is_admin: makeAdmin }),
+        });
+        if (adminStatus) {
+          adminStatus.textContent = makeAdmin
+            ? `Granted admin privileges to ${email}.`
+            : `Revoked admin privileges from ${email}.`;
+        }
+        if (response && response.user && currentUser.email && currentUser.email.toLowerCase() === email.toLowerCase()) {
+          setCurrentUser({ ...currentUser, ...response.user });
+        }
+        await loadAdminOverview(true);
+      } catch (err) {
+        console.error(err);
+        if (adminStatus) {
+          adminStatus.textContent = err instanceof Error ? err.message : 'Unable to update user.';
+        }
+      }
+    }
+
+    async function handleAdminResetPassword(email) {
+      if (!email || !currentUser || !currentUser.email || !currentUser.is_admin) {
+        return;
+      }
+      const nextPassword = window.prompt(`Enter a new password for ${email} (min. 8 characters)`);
+      if (nextPassword === null) {
+        return;
+      }
+      const trimmed = nextPassword.trim();
+      if (trimmed.length < 8) {
+        window.alert('Password must be at least 8 characters long.');
+        return;
+      }
+      const actor = encodeURIComponent(currentUser.email.toLowerCase());
+      try {
+        await apiFetch(`/admin/users/${encodeURIComponent(email)}?actor=${actor}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ password: trimmed }),
+        });
+        if (adminStatus) {
+          adminStatus.textContent = `Password reset for ${email}.`;
+        }
+      } catch (err) {
+        console.error(err);
+        if (adminStatus) {
+          adminStatus.textContent = err instanceof Error ? err.message : 'Unable to reset password.';
+        }
+      }
+    }
+
+    async function handleAdminDeleteUser(email) {
+      if (!email || !currentUser || !currentUser.email || !currentUser.is_admin) {
+        return;
+      }
+      if (!window.confirm(`Remove ${email}? Any claimed jobs will be released.`)) {
+        return;
+      }
+      const actor = encodeURIComponent(currentUser.email.toLowerCase());
+      try {
+        const response = await apiFetch(`/admin/users/${encodeURIComponent(email)}?actor=${actor}`, { method: 'DELETE' });
+        if (adminStatus) {
+          adminStatus.textContent = `Removed ${email}.`;
+        }
+        const lowerEmail = email.toLowerCase();
+        const removedSelf = (response && response.self) || (currentUser.email && currentUser.email.toLowerCase() === lowerEmail);
+        if (removedSelf) {
+          setCurrentUser(null);
+        } else {
+          await Promise.all([loadAdminOverview(true), loadJobs(true)]);
+        }
+      } catch (err) {
+        console.error(err);
+        if (adminStatus) {
+          adminStatus.textContent = err instanceof Error ? err.message : 'Unable to remove user.';
+        }
+      }
+    }
+
+    if (formCreateJob) {
+      formCreateJob.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!currentUser || !currentUser.email) {
+          statusEl.textContent = 'Sign in to publish jobs.';
+          toggleAuthSheet(true, 'login');
+          return;
+        }
+
+        const titleValue = jobTitle ? jobTitle.value.trim() : '';
+        const payloadValue = jobPayload ? jobPayload.value.trim() : '';
+        const departureValue = jobDeparture ? jobDeparture.value.trim().toUpperCase() : '';
+        const arrivalValue = jobArrival ? jobArrival.value.trim().toUpperCase() : '';
+        const deadlineValue = jobDeadline ? jobDeadline.value : '';
+        const notesValue = jobNotes ? jobNotes.value.trim() : '';
+
+        if (!titleValue || !payloadValue || !departureValue || !arrivalValue || !deadlineValue) {
+          statusEl.textContent = 'All required fields must be completed.';
+          return;
+        }
+
+        const deadlineDate = new Date(deadlineValue);
+        if (Number.isNaN(deadlineDate.getTime())) {
+          statusEl.textContent = 'Deadline must be a valid date/time.';
+          return;
+        }
+
+        let weightValue = null;
+        if (jobWeight && jobWeight.value.trim()) {
+          const parsed = Number(jobWeight.value);
+          if (!Number.isFinite(parsed) || parsed < 0) {
+            statusEl.textContent = 'Weight must be a positive number.';
+            return;
+          }
+          weightValue = parsed;
+        }
+
+        const payloadBody = {
+          title: titleValue,
+          platform: 'Microsoft Flight Simulator',
+          payload: payloadValue,
+          weight_lbs: weightValue,
+          departure_airport: departureValue,
+          arrival_airport: arrivalValue,
+          deadline: deadlineDate.toISOString(),
+          notes: notesValue || null,
+          created_by: currentUser.email.toLowerCase(),
+          legs: [{ seq: 1, mode: 'flight' }],
+        };
+
+        statusEl.textContent = 'Publishing job...';
+        try {
+          await apiFetch('/jobs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payloadBody),
+          });
+          formCreateJob.reset();
+          if (jobDeparture) {
+            jobDeparture.value = departureValue;
+          }
+          if (jobArrival) {
+            jobArrival.value = arrivalValue;
+          }
+          if (jobWeight) {
+            jobWeight.value = weightValue !== null ? String(weightValue) : '';
+          }
+          setJobDeadlineDefault(jobDeadline);
+          await loadJobs(true);
+          statusEl.textContent = 'Job created.';
+        } catch (err) {
+          console.error(err);
+          statusEl.textContent = err instanceof Error ? err.message : 'Unable to create job.';
+        }
+      });
+    }
+
+    if (btnJobsGenerate) {
+      btnJobsGenerate.addEventListener('click', async () => {
+        if (btnJobsGenerate.disabled) {
+          return;
+        }
+        btnJobsGenerate.disabled = true;
+        btnJobsGenerate.classList.add('opacity-60', 'cursor-not-allowed');
+        statusEl.textContent = 'Requesting SimuNet missions…';
+        try {
+          const res = await apiFetch('/jobs/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ count: 3 }),
+          });
+          await loadJobs(false);
+          const created = res && typeof res === 'object' && res !== null
+            ? (Array.isArray(res.jobs) ? res.jobs.length : (typeof res.count === 'number' ? res.count : 0))
+            : 0;
+          if (created > 0) {
+            statusEl.textContent = `SimuNet generated ${created} new job${created === 1 ? '' : 's'}.`;
+          } else {
+            statusEl.textContent = 'SimuNet had no new missions ready.';
+          }
+        } catch (err) {
+          console.error(err);
+          statusEl.textContent = err instanceof Error ? err.message : 'Unable to request SimuNet missions.';
+        } finally {
+          btnJobsGenerate.disabled = false;
+          btnJobsGenerate.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+      });
+    }
+
+    if (formAdminJob) {
+      formAdminJob.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        if (!currentUser || !currentUser.email || !currentUser.is_admin) {
+          if (adminStatus) {
+            adminStatus.textContent = 'Admin access required to publish missions.';
+          }
+          toggleAuthSheet(true, 'login');
+          return;
+        }
+
+        const titleValue = adminJobTitle ? adminJobTitle.value.trim() : '';
+        const payloadValue = adminJobPayload ? adminJobPayload.value.trim() : '';
+        const departureValue = adminJobDeparture ? adminJobDeparture.value.trim().toUpperCase() : '';
+        const arrivalValue = adminJobArrival ? adminJobArrival.value.trim().toUpperCase() : '';
+        const deadlineValue = adminJobDeadline ? adminJobDeadline.value : '';
+        const notesValue = adminJobNotes ? adminJobNotes.value.trim() : '';
+        const assignedValue = adminJobAssign ? adminJobAssign.value.trim().toLowerCase() : '';
+
+        if (!titleValue || !payloadValue || !departureValue || !arrivalValue || !deadlineValue) {
+          if (adminStatus) {
+            adminStatus.textContent = 'All required fields must be completed.';
+          }
+          return;
+        }
+
+        const deadlineDate = new Date(deadlineValue);
+        if (Number.isNaN(deadlineDate.getTime())) {
+          if (adminStatus) {
+            adminStatus.textContent = 'Deadline must be a valid date/time.';
+          }
+          return;
+        }
+
+        let weightValue = null;
+        if (adminJobWeight && adminJobWeight.value.trim()) {
+          const parsed = Number(adminJobWeight.value);
+          if (!Number.isFinite(parsed) || parsed < 0) {
+            if (adminStatus) {
+              adminStatus.textContent = 'Weight must be a positive number.';
+            }
+            return;
+          }
+          weightValue = parsed;
+        }
+
+        const payloadBody = {
+          title: titleValue,
+          platform: 'Microsoft Flight Simulator',
+          payload: payloadValue,
+          weight_lbs: weightValue,
+          departure_airport: departureValue,
+          arrival_airport: arrivalValue,
+          deadline: deadlineDate.toISOString(),
+          notes: notesValue || null,
+          created_by: currentUser.email.toLowerCase(),
+          assigned_to: assignedValue || null,
+          legs: [{ seq: 1, mode: 'flight' }],
+        };
+
+        if (adminStatus) {
+          adminStatus.textContent = 'Publishing mission…';
+        }
+
+        try {
+          await apiFetch('/jobs', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payloadBody),
+          });
+          formAdminJob.reset();
+          setJobDeadlineDefault(adminJobDeadline);
+          if (adminJobDeparture) {
+            adminJobDeparture.value = departureValue;
+          }
+          if (adminJobArrival) {
+            adminJobArrival.value = arrivalValue;
+          }
+          await Promise.all([loadJobs(false), loadAdminOverview(true)]);
+          if (adminStatus) {
+            adminStatus.textContent = 'Mission published.';
+          }
+        } catch (err) {
+          console.error(err);
+          if (adminStatus) {
+            adminStatus.textContent = err instanceof Error ? err.message : 'Unable to publish mission.';
+          }
+        }
+      });
+    }
+
+    if (btnAdminGenerate) {
+      btnAdminGenerate.addEventListener('click', async () => {
+        if (!currentUser || !currentUser.email || !currentUser.is_admin) {
+          if (adminStatus) {
+            adminStatus.textContent = 'Admin access required for auto-generation.';
+          }
+          toggleAuthSheet(true, 'login');
+          return;
+        }
+        if (btnAdminGenerate.disabled) {
+          return;
+        }
+        btnAdminGenerate.disabled = true;
+        btnAdminGenerate.classList.add('opacity-60', 'cursor-not-allowed');
+        if (adminStatus) {
+          adminStatus.textContent = 'Requesting SimuNet missions…';
+        }
+        try {
+          const res = await apiFetch('/jobs/generate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ count: 3 }),
+          });
+          await Promise.all([loadJobs(false), loadAdminOverview(true)]);
+          const created = res && typeof res === 'object' && res !== null
+            ? (Array.isArray(res.jobs) ? res.jobs.length : (typeof res.count === 'number' ? res.count : 0))
+            : 0;
+          if (adminStatus) {
+            adminStatus.textContent = created > 0
+              ? `SimuNet generated ${created} new mission${created === 1 ? '' : 's'}.`
+              : 'SimuNet had no new missions ready.';
+          }
+        } catch (err) {
+          console.error(err);
+          if (adminStatus) {
+            adminStatus.textContent = err instanceof Error ? err.message : 'Unable to request missions.';
+          }
+        } finally {
+          btnAdminGenerate.disabled = false;
+          btnAdminGenerate.classList.remove('opacity-60', 'cursor-not-allowed');
+        }
+      });
+    }
+
+    if (btnAdminRefresh) {
+      btnAdminRefresh.addEventListener('click', () => {
+        loadAdminOverview(true);
+      });
+    }
+
+    if (btnJobsRefresh) {
+      btnJobsRefresh.addEventListener('click', () => loadJobs(true));
+    }
+
+    document.getElementById('btnSeed').addEventListener('click', async () => {
+      if (!currentUser || !currentUser.email) {
+        statusEl.textContent = 'Sign in to create demo jobs.';
+        toggleAuthSheet(true, 'login');
+        return;
+      }
       statusEl.textContent = 'Seeding...';
-      try{
-        const seeded = await apiFetch('/dev/reseed', { method:'POST' });
-        const started = await apiFetch('/flights?assignment_id='+encodeURIComponent(seeded.job_id)+'&seq=1&mode=truck', { method:'POST' });
+      try {
+        const email = currentUser.email.toLowerCase();
+        const seeded = await apiFetch('/dev/reseed', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email })
+        });
+        if (seeded && seeded.job_id) {
+          await loadJobs(false);
+        }
+        const started = await apiFetch(`/flights?assignment_id=${encodeURIComponent(seeded.job_id)}&seq=1&mode=flight`, { method: 'POST' });
         flightIdEl.value = started.flight_id;
         saveRecent(started.flight_id, 0);
-        statusEl.textContent = 'Created flight '+started.flight_id;
-      }catch(e){
-        console.error(e); statusEl.textContent = 'Seed/start failed.';
+        statusEl.textContent = 'Created flight ' + started.flight_id;
+      } catch (e) {
+        console.error(e);
+        statusEl.textContent = 'Seed/start failed.';
       }
     });
 
-    async function fetchTelemetry(fid){
-      const data = await apiFetch('/telemetry/'+encodeURIComponent(fid));
+    async function fetchTelemetry(fid) {
+      const data = await apiFetch('/telemetry/' + encodeURIComponent(fid));
       return data.points || [];
     }
-    function fitPath(points){
-      if(!points.length) return;
-      const latlngs = points.map(p => [p.lat, p.lon]);
-      map.fitBounds(L.latLngBounds(latlngs), { padding: [20,20] });
+
+    function fitPath(points) {
+      if (!points.length) return;
+      const latlngs = points.map((p) => [p.lat, p.lon]);
+      map.fitBounds(L.latLngBounds(latlngs), { padding: [20, 20] });
     }
-    function sleep(ms){ return new Promise(res=>setTimeout(res, ms)); }
+
+    function sleep(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
 
     const ctx = document.getElementById('altChart');
-    let altChart = new Chart(ctx, {
+    const altChart = new Chart(ctx, {
       type: 'line',
-      data: { labels: [], datasets: [{ label: 'Altitude', data: [], tension: 0.3 }]},
-      options: { plugins:{ legend:{ labels:{ color:'#cbd5e1' } } }, scales:{ x:{ ticks:{ color:'#cbd5e1' }}, y:{ ticks:{ color:'#cbd5e1' }}} }
+      data: { labels: [], datasets: [{ label: 'Altitude', data: [], tension: 0.3 }] },
+      options: { plugins: { legend: { labels: { color: '#cbd5e1' } } }, scales: { x: { ticks: { color: '#cbd5e1' } }, y: { ticks: { color: '#cbd5e1' } } } }
     });
 
-    document.getElementById('btnLoad').addEventListener('click', async ()=>{
-      const fid = flightIdEl.value.trim(); if(!fid){ alert('Enter a flight_id.'); return; }
+    document.getElementById('btnLoad').addEventListener('click', async () => {
+      const fid = flightIdEl.value.trim();
+      if (!fid) {
+        alert('Enter a flight_id.');
+        return;
+      }
       statusEl.textContent = 'Loading telemetry...';
-      try{
+      try {
         const pts = await fetchTelemetry(fid);
         kpiPoints.textContent = pts.length;
         saveRecent(fid, pts.length);
-        if(!pts.length){ statusEl.textContent = 'No points yet. Add via Demo Stream or your connector.'; return; }
-        const latlngs = pts.map(p => [p.lat, p.lon]);
+        if (!pts.length) {
+          statusEl.textContent = 'No points yet. Add via Demo Stream or your connector.';
+          return;
+        }
+        const latlngs = pts.map((p) => [p.lat, p.lon]);
         pathLine.setLatLngs(latlngs);
-        marker.setLatLng(latlngs[latlngs.length-1]);
+        marker.setLatLng(latlngs[latlngs.length - 1]);
         fitPath(pts);
-        altChart.data.labels = pts.map(p => p.k);
-        altChart.data.datasets[0].data = pts.map(p => p.alt || 0);
+        altChart.data.labels = pts.map((p) => p.k);
+        altChart.data.datasets[0].data = pts.map((p) => p.alt || 0);
         altChart.update();
-        document.getElementById('chartMeta').textContent = pts.length+' points • last k='+pts[pts.length-1].k;
-        for(const p of pts){ marker.setLatLng([p.lat, p.lon]); await sleep(110); }
-        statusEl.textContent = 'Rendered '+pts.length+' points.';
-      }catch(e){ console.error(e); statusEl.textContent = 'Load failed.'; }
+        chartMeta.textContent = pts.length + ' points • last k=' + pts[pts.length - 1].k;
+        for (const p of pts) {
+          marker.setLatLng([p.lat, p.lon]);
+          await sleep(110);
+        }
+        statusEl.textContent = 'Rendered ' + pts.length + ' points.';
+      } catch (e) {
+        console.error(e);
+        statusEl.textContent = 'Load failed.';
+      }
     });
 
-    document.getElementById('btnDemo').addEventListener('click', async ()=>{
-      const fid = flightIdEl.value.trim(); if(!fid){ alert('Create or paste a flight_id first.'); return; }
+    document.getElementById('btnDemo').addEventListener('click', async () => {
+      const fid = flightIdEl.value.trim();
+      if (!fid) {
+        alert('Create or paste a flight_id first.');
+        return;
+      }
       statusEl.textContent = 'Streaming demo telemetry...';
-      try{
-        let lat=40.7, lon=-74.0, alt=50;
-        for(let k=0; k<80; k++){
+      try {
+        let lat = 40.7;
+        let lon = -74.0;
+        let alt = 50;
+        for (let k = 0; k < 80; k++) {
           const pt = { flight_id: fid, k, lat, lon, alt, ts: new Date().toISOString() };
-          await apiFetch('/telemetry', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(pt)});
-          lat += 0.002; lon += 0.004; alt += (k%12===0? 20: 0);
+          await apiFetch('/telemetry', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(pt) });
+          lat += 0.002;
+          lon += 0.004;
+          alt += (k % 12 === 0 ? 20 : 0);
           await sleep(110);
         }
         statusEl.textContent = 'Demo stream complete. Click "Load & Animate".';
-      }catch(e){ console.error(e); statusEl.textContent = 'Demo stream failed.'; }
+      } catch (e) {
+        console.error(e);
+        statusEl.textContent = 'Demo stream failed.';
+      }
     });
 
-    document.getElementById('btnPing').click();
+    function updateNav(targetPage) {
+      navLinks.forEach((link) => {
+        const active = link.dataset.nav === targetPage;
+        link.classList.toggle('bg-white/10', active);
+        link.classList.toggle('text-white', active);
+        link.classList.toggle('text-slate-300', !active);
+      });
+    }
+
+    function showPage(page, { updateHash = true } = {}) {
+      let target = null;
+      pages.forEach((section) => {
+        if (section.dataset.page === page && !target) {
+          target = section;
+        }
+      });
+      if (!target) {
+        target = pages[0];
+        page = target ? target.dataset.page : 'dashboard';
+      }
+      pages.forEach((section) => {
+        section.classList.toggle('hidden', section !== target);
+      });
+      updateNav(page);
+      if (page === 'jobs') {
+        loadJobs(!jobsLoaded);
+      }
+      if (page === 'admin') {
+        if (currentUser && currentUser.is_admin) {
+          loadAdminOverview(!adminLoaded);
+        } else if (adminStatus) {
+          adminStatus.textContent = 'Admin privileges required to view this page.';
+        }
+      }
+      if (updateHash && ('#' + page) !== location.hash) {
+        history.replaceState(null, '', '#' + page);
+      }
+    }
+
+    navLinks.forEach((link) => {
+      link.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const page = link.dataset.nav || 'dashboard';
+        showPage(page);
+      });
+    });
+
+    window.addEventListener('hashchange', () => {
+      const page = location.hash.replace('#', '') || 'dashboard';
+      showPage(page, { updateHash: false });
+    });
+
+    loadStoredUser();
+
+    const initialPage = location.hash.replace('#', '') || 'dashboard';
+    showPage(initialPage, { updateHash: false });
+
+    checkStatus();
+    setInterval(() => checkStatus(false), 45000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a runtime schema patch that backfills the missing users.is_admin column when databases were created before the flag existed
- seed the SimuNet Ops address as an admin during the patch so legacy deployments can access the admin dashboard

## Testing
- python -m compileall backend
- python - <<'PY' from fastapi.testclient import TestClient; from backend.app import app; client = TestClient(app); resp = client.post('/auth/register', json={'email':'ops-auto@test.local','password':'password123'}); print(resp.status_code); print(resp.json()); PY


------
https://chatgpt.com/codex/tasks/task_e_68e05bb7e6b08329be330740dff49ccc